### PR TITLE
StepBuilder: inline steps with page model references should use model identifiers

### DIFF
--- a/src/Builder/StepBuilder.php
+++ b/src/Builder/StepBuilder.php
@@ -3,15 +3,16 @@
 namespace webignition\BasilParser\Builder;
 
 use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\NonRetrievablePageException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\StepFactory;
 use webignition\BasilParser\Loader\StepLoader;
 use webignition\BasilParser\Loader\YamlLoader;
 use webignition\BasilParser\Loader\YamlLoaderException;
-use webignition\BasilParser\Model\Page\PageInterface;
 use webignition\BasilParser\Model\PageElementReference\PageElementReference;
 use webignition\BasilParser\Model\Step\StepInterface;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 class StepBuilder
 {
@@ -35,26 +36,26 @@ class StepBuilder
      * @param array $stepData
      * @param string[] $stepImportPaths
      * @param string[] $dataProviderImportPaths
-     * @param PageInterface[] $pages
+     * @param PageCollectionInterface $pages
      *
      * @return StepInterface
      *
      * @throws StepBuilderInvalidPageElementReferenceException
      * @throws StepBuilderUnknownDataProviderImportException
      * @throws StepBuilderUnknownPageElementException
-     * @throws StepBuilderUnknownPageImportException
      * @throws StepBuilderUnknownStepImportException
      * @throws YamlLoaderException
      * @throws MalformedPageElementReferenceException
      * @throws UnknownPageElementException
      * @throws UnknownPageException
+     * @throws NonRetrievablePageException
      */
     public function build(
         string $stepName,
         array $stepData,
         array $stepImportPaths,
         array $dataProviderImportPaths,
-        array $pages
+        PageCollectionInterface $pages
     ) {
         $stepImportName = $stepData[self::KEY_USE] ?? null;
         if (null === $stepImportName) {
@@ -109,11 +110,7 @@ class StepBuilder
                 $pageImportName = $pageModelElementReference->getImportName();
                 $elementName = $pageModelElementReference->getElementName();
 
-                $page = $pages[$pageImportName] ?? null;
-
-                if (null === $page) {
-                    throw new StepBuilderUnknownPageImportException($stepName, $pageImportName, $pages);
-                }
+                $page = $pages->findPage($pageImportName);
 
                 $elementIdentifier = $page->getElementIdentifier($elementName);
 

--- a/src/Builder/StepBuilder.php
+++ b/src/Builder/StepBuilder.php
@@ -7,8 +7,8 @@ use webignition\BasilParser\Exception\NonRetrievablePageException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\StepFactory;
+use webignition\BasilParser\Loader\DataSetLoader;
 use webignition\BasilParser\Loader\StepLoader;
-use webignition\BasilParser\Loader\YamlLoader;
 use webignition\BasilParser\Loader\YamlLoaderException;
 use webignition\BasilParser\Model\PageElementReference\PageElementReference;
 use webignition\BasilParser\Model\Step\StepInterface;
@@ -22,13 +22,13 @@ class StepBuilder
 
     private $stepFactory;
     private $stepLoader;
-    private $yamlLoader;
+    private $dataSetLoader;
 
-    public function __construct(StepFactory $stepFactory, StepLoader $stepLoader, YamlLoader $yamlLoader)
+    public function __construct(StepFactory $stepFactory, StepLoader $stepLoader, DataSetLoader $dataSetLoader)
     {
         $this->stepFactory = $stepFactory;
         $this->stepLoader = $stepLoader;
-        $this->yamlLoader = $yamlLoader;
+        $this->dataSetLoader = $dataSetLoader;
     }
 
     /**
@@ -84,7 +84,7 @@ class StepBuilder
                     );
                 }
 
-                $data = $this->yamlLoader->loadArray($dataProviderImportPath);
+                $data = $this->dataSetLoader->load($dataProviderImportPath);
             }
 
             if (is_array($data)) {

--- a/src/Builder/StepBuilderInvalidPageElementReferenceException.php
+++ b/src/Builder/StepBuilderInvalidPageElementReferenceException.php
@@ -2,7 +2,7 @@
 
 namespace webignition\BasilParser\Builder;
 
-class InvalidPageElementReferenceException extends \Exception
+class StepBuilderInvalidPageElementReferenceException extends \Exception
 {
     private $stepName;
     private $pageElementReference;

--- a/src/Builder/StepBuilderUnknownDataProviderImportException.php
+++ b/src/Builder/StepBuilderUnknownDataProviderImportException.php
@@ -2,7 +2,7 @@
 
 namespace webignition\BasilParser\Builder;
 
-class UnknownDataProviderImportException extends \Exception
+class StepBuilderUnknownDataProviderImportException extends \Exception
 {
     private $stepName;
     private $importName;

--- a/src/Builder/StepBuilderUnknownPageElementException.php
+++ b/src/Builder/StepBuilderUnknownPageElementException.php
@@ -2,7 +2,7 @@
 
 namespace webignition\BasilParser\Builder;
 
-class UnknownPageElementException extends \Exception
+class StepBuilderUnknownPageElementException extends \Exception
 {
     private $stepName;
     private $importName;

--- a/src/Builder/StepBuilderUnknownPageImportException.php
+++ b/src/Builder/StepBuilderUnknownPageImportException.php
@@ -2,7 +2,7 @@
 
 namespace webignition\BasilParser\Builder;
 
-class UnknownPageImportException extends \Exception
+class StepBuilderUnknownPageImportException extends \Exception
 {
     private $stepName;
     private $importName;

--- a/src/Builder/StepBuilderUnknownStepImportException.php
+++ b/src/Builder/StepBuilderUnknownStepImportException.php
@@ -2,7 +2,7 @@
 
 namespace webignition\BasilParser\Builder;
 
-class UnknownStepImportException extends \Exception
+class StepBuilderUnknownStepImportException extends \Exception
 {
     private $stepName;
     private $importName;

--- a/src/Exception/InvalidPageElementReferenceException.php
+++ b/src/Exception/InvalidPageElementReferenceException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace webignition\BasilParser\Exception;
+
+use webignition\BasilParser\Model\PageElementReference\PageElementReference;
+
+class InvalidPageElementReferenceException extends \Exception
+{
+    private $pageElementReference;
+
+    public function __construct(PageElementReference $pageElementReference)
+    {
+        parent::__construct('Invalid page element reference "' . (string) $pageElementReference . '"');
+
+        $this->pageElementReference = $pageElementReference;
+    }
+
+    public function getPageElementReference(): PageElementReference
+    {
+        return $this->pageElementReference;
+    }
+}

--- a/src/Exception/MalformedPageElementReferenceException.php
+++ b/src/Exception/MalformedPageElementReferenceException.php
@@ -4,13 +4,13 @@ namespace webignition\BasilParser\Exception;
 
 use webignition\BasilParser\Model\PageElementReference\PageElementReference;
 
-class InvalidPageElementReferenceException extends \Exception
+class MalformedPageElementReferenceException extends \Exception
 {
     private $pageElementReference;
 
     public function __construct(PageElementReference $pageElementReference)
     {
-        parent::__construct('Invalid page element reference "' . (string) $pageElementReference . '"');
+        parent::__construct('Malformed page element reference "' . (string) $pageElementReference . '"');
 
         $this->pageElementReference = $pageElementReference;
     }

--- a/src/Exception/NonRetrievablePageException.php
+++ b/src/Exception/NonRetrievablePageException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace webignition\BasilParser\Exception;
+
+class NonRetrievablePageException extends \Exception
+{
+    private $importName;
+    private $importPath;
+
+    public function __construct(string $importName, string $importPath, \Throwable $previous)
+    {
+        parent::__construct(
+            'Cannot retrieve page "' . $importName . '" from "' . $importPath . '"',
+            0,
+            $previous
+        );
+
+        $this->importName = $importName;
+        $this->importPath = $importPath;
+    }
+
+    public function getImportName(): string
+    {
+        return $this->importName;
+    }
+
+    public function getImportPath(): string
+    {
+        return $this->importPath;
+    }
+}

--- a/src/Exception/UnknownPageElementException.php
+++ b/src/Exception/UnknownPageElementException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace webignition\BasilParser\Exception;
+
+class UnknownPageElementException extends \Exception
+{
+    private $importName;
+    private $elementName;
+
+    public function __construct(string $importName, string $elementName)
+    {
+        parent::__construct('Unknown page element "' . $elementName . '" in page "' . $importName . '"');
+
+        $this->importName = $importName;
+        $this->elementName = $elementName;
+    }
+
+    public function getImportName(): string
+    {
+        return $this->importName;
+    }
+
+    public function getElementName(): string
+    {
+        return $this->elementName;
+    }
+}

--- a/src/Exception/UnknownPageException.php
+++ b/src/Exception/UnknownPageException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace webignition\BasilParser\Exception;
+
+class UnknownPageException extends \Exception
+{
+    private $importName;
+
+    public function __construct(string $importName)
+    {
+        parent::__construct('Unknown page "' . $importName . '"');
+
+        $this->importName = $importName;
+    }
+
+    public function getImportName(): string
+    {
+        return $this->importName;
+    }
+}

--- a/src/Factory/Action/AbstractActionFactory.php
+++ b/src/Factory/Action/AbstractActionFactory.php
@@ -27,10 +27,10 @@ abstract class AbstractActionFactory implements ActionFactoryInterface
     abstract protected function doCreateFromTypeAndArguments(
         string $type,
         string $arguments,
-        array $pages = []
+        array $pages
     ): ActionInterface;
 
-    public function createFromActionString(string $actionString, array $pages = []): ActionInterface
+    public function createFromActionString(string $actionString, array $pages): ActionInterface
     {
         $actionString = trim($actionString);
 
@@ -44,7 +44,7 @@ abstract class AbstractActionFactory implements ActionFactoryInterface
         return $this->createFromTypeAndArguments($type, $arguments, $pages);
     }
 
-    public function createFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
+    public function createFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
     {
         if (!$this->handles($type)) {
             throw new \RuntimeException('Invalid action type');

--- a/src/Factory/Action/AbstractActionFactory.php
+++ b/src/Factory/Action/AbstractActionFactory.php
@@ -3,6 +3,7 @@
 namespace webignition\BasilParser\Factory\Action;
 
 use webignition\BasilParser\Model\Action\ActionInterface;
+use webignition\BasilParser\Model\Page\PageInterface;
 
 abstract class AbstractActionFactory implements ActionFactoryInterface
 {
@@ -16,9 +17,20 @@ abstract class AbstractActionFactory implements ActionFactoryInterface
      */
     abstract protected function getHandledActionTypes(): array;
 
-    abstract protected function doCreateFromTypeAndArguments(string $type, string $arguments): ActionInterface;
+    /**
+     * @param string $type
+     * @param string $arguments
+     * @param PageInterface[] $pages
+     *
+     * @return ActionInterface
+     */
+    abstract protected function doCreateFromTypeAndArguments(
+        string $type,
+        string $arguments,
+        array $pages = []
+    ): ActionInterface;
 
-    public function createFromActionString(string $actionString): ActionInterface
+    public function createFromActionString(string $actionString, array $pages = []): ActionInterface
     {
         $actionString = trim($actionString);
 
@@ -29,15 +41,15 @@ abstract class AbstractActionFactory implements ActionFactoryInterface
             list($type, $arguments) = explode(' ', $actionString, 2);
         }
 
-        return $this->createFromTypeAndArguments($type, $arguments);
+        return $this->createFromTypeAndArguments($type, $arguments, $pages);
     }
 
-    public function createFromTypeAndArguments(string $type, string $arguments): ActionInterface
+    public function createFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
     {
         if (!$this->handles($type)) {
             throw new \RuntimeException('Invalid action type');
         }
 
-        return $this->doCreateFromTypeAndArguments($type, $arguments);
+        return $this->doCreateFromTypeAndArguments($type, $arguments, $pages);
     }
 }

--- a/src/Factory/Action/AbstractActionFactory.php
+++ b/src/Factory/Action/AbstractActionFactory.php
@@ -3,7 +3,7 @@
 namespace webignition\BasilParser\Factory\Action;
 
 use webignition\BasilParser\Model\Action\ActionInterface;
-use webignition\BasilParser\Model\Page\PageInterface;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 abstract class AbstractActionFactory implements ActionFactoryInterface
 {
@@ -20,17 +20,17 @@ abstract class AbstractActionFactory implements ActionFactoryInterface
     /**
      * @param string $type
      * @param string $arguments
-     * @param PageInterface[] $pages
+     * @param PageCollectionInterface $pages
      *
      * @return ActionInterface
      */
     abstract protected function doCreateFromTypeAndArguments(
         string $type,
         string $arguments,
-        array $pages
+        PageCollectionInterface $pages
     ): ActionInterface;
 
-    public function createFromActionString(string $actionString, array $pages): ActionInterface
+    public function createFromActionString(string $actionString, PageCollectionInterface $pages): ActionInterface
     {
         $actionString = trim($actionString);
 
@@ -44,8 +44,11 @@ abstract class AbstractActionFactory implements ActionFactoryInterface
         return $this->createFromTypeAndArguments($type, $arguments, $pages);
     }
 
-    public function createFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
-    {
+    public function createFromTypeAndArguments(
+        string $type,
+        string $arguments,
+        PageCollectionInterface $pages
+    ): ActionInterface {
         if (!$this->handles($type)) {
             throw new \RuntimeException('Invalid action type');
         }

--- a/src/Factory/Action/ActionFactory.php
+++ b/src/Factory/Action/ActionFactory.php
@@ -4,6 +4,7 @@ namespace webignition\BasilParser\Factory\Action;
 
 use webignition\BasilParser\Model\Action\ActionInterface;
 use webignition\BasilParser\Model\Action\ActionTypes;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 class ActionFactory extends AbstractActionFactory implements ActionFactoryInterface
 {
@@ -37,8 +38,11 @@ class ActionFactory extends AbstractActionFactory implements ActionFactoryInterf
         return ActionTypes::ALL;
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
-    {
+    protected function doCreateFromTypeAndArguments(
+        string $type,
+        string $arguments,
+        PageCollectionInterface $pages
+    ): ActionInterface {
         return $this->findTypeSpecificActionFactory($type)->createFromTypeAndArguments($type, $arguments, $pages);
     }
 

--- a/src/Factory/Action/ActionFactory.php
+++ b/src/Factory/Action/ActionFactory.php
@@ -37,9 +37,9 @@ class ActionFactory extends AbstractActionFactory implements ActionFactoryInterf
         return ActionTypes::ALL;
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments): ActionInterface
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
     {
-        return $this->findTypeSpecificActionFactory($type)->createFromTypeAndArguments($type, $arguments);
+        return $this->findTypeSpecificActionFactory($type)->createFromTypeAndArguments($type, $arguments, $pages);
     }
 
     private function findTypeSpecificActionFactory(string $type): ActionFactoryInterface

--- a/src/Factory/Action/ActionFactory.php
+++ b/src/Factory/Action/ActionFactory.php
@@ -37,7 +37,7 @@ class ActionFactory extends AbstractActionFactory implements ActionFactoryInterf
         return ActionTypes::ALL;
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
     {
         return $this->findTypeSpecificActionFactory($type)->createFromTypeAndArguments($type, $arguments, $pages);
     }

--- a/src/Factory/Action/ActionFactoryInterface.php
+++ b/src/Factory/Action/ActionFactoryInterface.php
@@ -15,7 +15,7 @@ interface ActionFactoryInterface
      *
      * @return ActionInterface
      */
-    public function createFromActionString(string $actionString, array $pages = []): ActionInterface;
+    public function createFromActionString(string $actionString, array $pages): ActionInterface;
 
     /**
      * @param string $type
@@ -24,5 +24,5 @@ interface ActionFactoryInterface
      *
      * @return ActionInterface
      */
-    public function createFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface;
+    public function createFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface;
 }

--- a/src/Factory/Action/ActionFactoryInterface.php
+++ b/src/Factory/Action/ActionFactoryInterface.php
@@ -3,7 +3,7 @@
 namespace webignition\BasilParser\Factory\Action;
 
 use webignition\BasilParser\Model\Action\ActionInterface;
-use webignition\BasilParser\Model\Page\PageInterface;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 interface ActionFactoryInterface
 {
@@ -11,18 +11,22 @@ interface ActionFactoryInterface
 
     /**
      * @param string $actionString
-     * @param PageInterface[] $pages
+     * @param PageCollectionInterface $pages
      *
      * @return ActionInterface
      */
-    public function createFromActionString(string $actionString, array $pages): ActionInterface;
+    public function createFromActionString(string $actionString, PageCollectionInterface $pages): ActionInterface;
 
     /**
      * @param string $type
      * @param string $arguments
-     * @param PageInterface[] $pages
+     * @param PageCollectionInterface $pages
      *
      * @return ActionInterface
      */
-    public function createFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface;
+    public function createFromTypeAndArguments(
+        string $type,
+        string $arguments,
+        PageCollectionInterface $pages
+    ): ActionInterface;
 }

--- a/src/Factory/Action/ActionFactoryInterface.php
+++ b/src/Factory/Action/ActionFactoryInterface.php
@@ -3,10 +3,26 @@
 namespace webignition\BasilParser\Factory\Action;
 
 use webignition\BasilParser\Model\Action\ActionInterface;
+use webignition\BasilParser\Model\Page\PageInterface;
 
 interface ActionFactoryInterface
 {
     public function handles(string $type): bool;
-    public function createFromActionString(string $actionString): ActionInterface;
-    public function createFromTypeAndArguments(string $type, string $arguments): ActionInterface;
+
+    /**
+     * @param string $actionString
+     * @param PageInterface[] $pages
+     *
+     * @return ActionInterface
+     */
+    public function createFromActionString(string $actionString, array $pages = []): ActionInterface;
+
+    /**
+     * @param string $type
+     * @param string $arguments
+     * @param PageInterface[] $pages
+     *
+     * @return ActionInterface
+     */
+    public function createFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface;
 }

--- a/src/Factory/Action/InputActionFactory.php
+++ b/src/Factory/Action/InputActionFactory.php
@@ -2,12 +2,16 @@
 
 namespace webignition\BasilParser\Factory\Action;
 
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\UnknownPageElementException;
+use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\IdentifierFactory;
 use webignition\BasilParser\Factory\ValueFactory;
 use webignition\BasilParser\IdentifierStringExtractor\IdentifierStringExtractor;
 use webignition\BasilParser\Model\Action\ActionInterface;
 use webignition\BasilParser\Model\Action\ActionTypes;
 use webignition\BasilParser\Model\Action\InputAction;
+use webignition\BasilParser\Model\Page\PageInterface;
 
 class InputActionFactory extends AbstractActionFactory implements ActionFactoryInterface
 {
@@ -31,7 +35,18 @@ class InputActionFactory extends AbstractActionFactory implements ActionFactoryI
         ];
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments): ActionInterface
+    /**
+     * @param string $type
+     * @param string $arguments
+     * @param PageInterface[] $pages
+     *
+     * @return ActionInterface
+     *
+     * @throws MalformedPageElementReferenceException
+     * @throws UnknownPageElementException
+     * @throws UnknownPageException
+     */
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
     {
         $identifierString = $this->identifierStringExtractor->extractFromStart($arguments);
 
@@ -39,7 +54,7 @@ class InputActionFactory extends AbstractActionFactory implements ActionFactoryI
             return new InputAction(null, null, $arguments);
         }
 
-        $identifier = $this->identifierFactory->create($identifierString);
+        $identifier = $this->identifierFactory->create($identifierString, $pages);
 
         $trimmedStopWord = trim(self::IDENTIFIER_STOP_WORD);
         $endsWithStopStringRegex = '/(( ' . $trimmedStopWord . ' )|( ' . $trimmedStopWord . '))$/';

--- a/src/Factory/Action/InputActionFactory.php
+++ b/src/Factory/Action/InputActionFactory.php
@@ -46,7 +46,7 @@ class InputActionFactory extends AbstractActionFactory implements ActionFactoryI
      * @throws UnknownPageElementException
      * @throws UnknownPageException
      */
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
     {
         $identifierString = $this->identifierStringExtractor->extractFromStart($arguments);
 

--- a/src/Factory/Action/InputActionFactory.php
+++ b/src/Factory/Action/InputActionFactory.php
@@ -3,6 +3,7 @@
 namespace webignition\BasilParser\Factory\Action;
 
 use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\NonRetrievablePageException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\IdentifierFactory;
@@ -11,7 +12,7 @@ use webignition\BasilParser\IdentifierStringExtractor\IdentifierStringExtractor;
 use webignition\BasilParser\Model\Action\ActionInterface;
 use webignition\BasilParser\Model\Action\ActionTypes;
 use webignition\BasilParser\Model\Action\InputAction;
-use webignition\BasilParser\Model\Page\PageInterface;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 class InputActionFactory extends AbstractActionFactory implements ActionFactoryInterface
 {
@@ -38,16 +39,20 @@ class InputActionFactory extends AbstractActionFactory implements ActionFactoryI
     /**
      * @param string $type
      * @param string $arguments
-     * @param PageInterface[] $pages
+     * @param PageCollectionInterface $pages
      *
      * @return ActionInterface
      *
      * @throws MalformedPageElementReferenceException
      * @throws UnknownPageElementException
      * @throws UnknownPageException
+     * @throws NonRetrievablePageException
      */
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
-    {
+    protected function doCreateFromTypeAndArguments(
+        string $type,
+        string $arguments,
+        PageCollectionInterface $pages
+    ): ActionInterface {
         $identifierString = $this->identifierStringExtractor->extractFromStart($arguments);
 
         if ('' === $identifierString) {

--- a/src/Factory/Action/InteractionActionFactory.php
+++ b/src/Factory/Action/InteractionActionFactory.php
@@ -3,13 +3,14 @@
 namespace webignition\BasilParser\Factory\Action;
 
 use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\NonRetrievablePageException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\IdentifierFactory;
 use webignition\BasilParser\Model\Action\ActionInterface;
 use webignition\BasilParser\Model\Action\ActionTypes;
 use webignition\BasilParser\Model\Action\InteractionAction;
-use webignition\BasilParser\Model\Page\PageInterface;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 class InteractionActionFactory extends AbstractActionFactory implements ActionFactoryInterface
 {
@@ -34,16 +35,20 @@ class InteractionActionFactory extends AbstractActionFactory implements ActionFa
     /**
      * @param string $type
      * @param string $arguments
-     * @param PageInterface[] $pages
+     * @param PageCollectionInterface $pages
      *
      * @return ActionInterface
      *
      * @throws MalformedPageElementReferenceException
      * @throws UnknownPageElementException
      * @throws UnknownPageException
+     * @throws NonRetrievablePageException
      */
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
-    {
+    protected function doCreateFromTypeAndArguments(
+        string $type,
+        string $arguments,
+        PageCollectionInterface $pages
+    ): ActionInterface {
         return new InteractionAction($type, $this->identifierFactory->create($arguments, $pages), $arguments);
     }
 }

--- a/src/Factory/Action/InteractionActionFactory.php
+++ b/src/Factory/Action/InteractionActionFactory.php
@@ -42,7 +42,7 @@ class InteractionActionFactory extends AbstractActionFactory implements ActionFa
      * @throws UnknownPageElementException
      * @throws UnknownPageException
      */
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
     {
         return new InteractionAction($type, $this->identifierFactory->create($arguments, $pages), $arguments);
     }

--- a/src/Factory/Action/InteractionActionFactory.php
+++ b/src/Factory/Action/InteractionActionFactory.php
@@ -2,10 +2,14 @@
 
 namespace webignition\BasilParser\Factory\Action;
 
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\UnknownPageElementException;
+use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\IdentifierFactory;
 use webignition\BasilParser\Model\Action\ActionInterface;
 use webignition\BasilParser\Model\Action\ActionTypes;
 use webignition\BasilParser\Model\Action\InteractionAction;
+use webignition\BasilParser\Model\Page\PageInterface;
 
 class InteractionActionFactory extends AbstractActionFactory implements ActionFactoryInterface
 {
@@ -27,8 +31,19 @@ class InteractionActionFactory extends AbstractActionFactory implements ActionFa
         ];
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments): ActionInterface
+    /**
+     * @param string $type
+     * @param string $arguments
+     * @param PageInterface[] $pages
+     *
+     * @return ActionInterface
+     *
+     * @throws MalformedPageElementReferenceException
+     * @throws UnknownPageElementException
+     * @throws UnknownPageException
+     */
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
     {
-        return new InteractionAction($type, $this->identifierFactory->create($arguments), $arguments);
+        return new InteractionAction($type, $this->identifierFactory->create($arguments, $pages), $arguments);
     }
 }

--- a/src/Factory/Action/NoArgumentsActionFactory.php
+++ b/src/Factory/Action/NoArgumentsActionFactory.php
@@ -5,6 +5,7 @@ namespace webignition\BasilParser\Factory\Action;
 use webignition\BasilParser\Model\Action\NoArgumentsAction;
 use webignition\BasilParser\Model\Action\ActionInterface;
 use webignition\BasilParser\Model\Action\ActionTypes;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 class NoArgumentsActionFactory extends AbstractActionFactory implements ActionFactoryInterface
 {
@@ -17,8 +18,11 @@ class NoArgumentsActionFactory extends AbstractActionFactory implements ActionFa
         ];
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
-    {
+    protected function doCreateFromTypeAndArguments(
+        string $type,
+        string $arguments,
+        PageCollectionInterface $pages
+    ): ActionInterface {
         return new NoArgumentsAction($type, $arguments);
     }
 }

--- a/src/Factory/Action/NoArgumentsActionFactory.php
+++ b/src/Factory/Action/NoArgumentsActionFactory.php
@@ -17,7 +17,7 @@ class NoArgumentsActionFactory extends AbstractActionFactory implements ActionFa
         ];
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments): ActionInterface
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
     {
         return new NoArgumentsAction($type, $arguments);
     }

--- a/src/Factory/Action/NoArgumentsActionFactory.php
+++ b/src/Factory/Action/NoArgumentsActionFactory.php
@@ -17,7 +17,7 @@ class NoArgumentsActionFactory extends AbstractActionFactory implements ActionFa
         ];
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
     {
         return new NoArgumentsAction($type, $arguments);
     }

--- a/src/Factory/Action/UnrecognisedActionFactory.php
+++ b/src/Factory/Action/UnrecognisedActionFactory.php
@@ -4,6 +4,7 @@ namespace webignition\BasilParser\Factory\Action;
 
 use webignition\BasilParser\Model\Action\ActionInterface;
 use webignition\BasilParser\Model\Action\UnrecognisedAction;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 class UnrecognisedActionFactory implements ActionFactoryInterface
 {
@@ -12,15 +13,18 @@ class UnrecognisedActionFactory implements ActionFactoryInterface
         return true;
     }
 
-    public function createFromActionString(string $actionString, array $pages): ActionInterface
+    public function createFromActionString(string $actionString, PageCollectionInterface $pages): ActionInterface
     {
         list($type, $arguments) = explode(' ', $actionString, 2);
 
         return $this->createFromTypeAndArguments($type, $arguments, $pages);
     }
 
-    public function createFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
-    {
+    public function createFromTypeAndArguments(
+        string $type,
+        string $arguments,
+        PageCollectionInterface $pages
+    ): ActionInterface {
         return new UnrecognisedAction($type, $arguments);
     }
 }

--- a/src/Factory/Action/UnrecognisedActionFactory.php
+++ b/src/Factory/Action/UnrecognisedActionFactory.php
@@ -12,14 +12,14 @@ class UnrecognisedActionFactory implements ActionFactoryInterface
         return true;
     }
 
-    public function createFromActionString(string $actionString, array $pages = []): ActionInterface
+    public function createFromActionString(string $actionString, array $pages): ActionInterface
     {
         list($type, $arguments) = explode(' ', $actionString, 2);
 
         return $this->createFromTypeAndArguments($type, $arguments, $pages);
     }
 
-    public function createFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
+    public function createFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
     {
         return new UnrecognisedAction($type, $arguments);
     }

--- a/src/Factory/Action/UnrecognisedActionFactory.php
+++ b/src/Factory/Action/UnrecognisedActionFactory.php
@@ -12,14 +12,14 @@ class UnrecognisedActionFactory implements ActionFactoryInterface
         return true;
     }
 
-    public function createFromActionString(string $actionString): ActionInterface
+    public function createFromActionString(string $actionString, array $pages = []): ActionInterface
     {
         list($type, $arguments) = explode(' ', $actionString, 2);
 
-        return $this->createFromTypeAndArguments($type, $arguments);
+        return $this->createFromTypeAndArguments($type, $arguments, $pages);
     }
 
-    public function createFromTypeAndArguments(string $type, string $arguments): ActionInterface
+    public function createFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
     {
         return new UnrecognisedAction($type, $arguments);
     }

--- a/src/Factory/Action/WaitActionFactory.php
+++ b/src/Factory/Action/WaitActionFactory.php
@@ -15,7 +15,7 @@ class WaitActionFactory extends AbstractActionFactory implements ActionFactoryIn
         ];
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
     {
         return new WaitAction($arguments);
     }

--- a/src/Factory/Action/WaitActionFactory.php
+++ b/src/Factory/Action/WaitActionFactory.php
@@ -15,7 +15,7 @@ class WaitActionFactory extends AbstractActionFactory implements ActionFactoryIn
         ];
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments): ActionInterface
+    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages = []): ActionInterface
     {
         return new WaitAction($arguments);
     }

--- a/src/Factory/Action/WaitActionFactory.php
+++ b/src/Factory/Action/WaitActionFactory.php
@@ -5,6 +5,7 @@ namespace webignition\BasilParser\Factory\Action;
 use webignition\BasilParser\Model\Action\ActionInterface;
 use webignition\BasilParser\Model\Action\ActionTypes;
 use webignition\BasilParser\Model\Action\WaitAction;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 class WaitActionFactory extends AbstractActionFactory implements ActionFactoryInterface
 {
@@ -15,8 +16,11 @@ class WaitActionFactory extends AbstractActionFactory implements ActionFactoryIn
         ];
     }
 
-    protected function doCreateFromTypeAndArguments(string $type, string $arguments, array $pages): ActionInterface
-    {
+    protected function doCreateFromTypeAndArguments(
+        string $type,
+        string $arguments,
+        PageCollectionInterface $pages
+    ): ActionInterface {
         return new WaitAction($arguments);
     }
 }

--- a/src/Factory/AssertionFactory.php
+++ b/src/Factory/AssertionFactory.php
@@ -2,7 +2,7 @@
 
 namespace webignition\BasilParser\Factory;
 
-use webignition\BasilParser\Exception\InvalidPageElementReferenceException;
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\IdentifierStringExtractor\IdentifierStringExtractor;
@@ -30,7 +30,7 @@ class AssertionFactory
      *
      * @return AssertionInterface
      *
-     * @throws InvalidPageElementReferenceException
+     * @throws MalformedPageElementReferenceException
      * @throws UnknownPageElementException
      * @throws UnknownPageException
      */

--- a/src/Factory/AssertionFactory.php
+++ b/src/Factory/AssertionFactory.php
@@ -3,13 +3,14 @@
 namespace webignition\BasilParser\Factory;
 
 use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\NonRetrievablePageException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\IdentifierStringExtractor\IdentifierStringExtractor;
 use webignition\BasilParser\Model\Assertion\Assertion;
 use webignition\BasilParser\Model\Assertion\AssertionComparisons;
 use webignition\BasilParser\Model\Assertion\AssertionInterface;
-use webignition\BasilParser\Model\Page\PageInterface;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 class AssertionFactory
 {
@@ -26,19 +27,22 @@ class AssertionFactory
 
     /**
      * @param string $assertionString
-     * @param PageInterface[] $pages
+     * @param PageCollectionInterface $pageCollection
      *
      * @return AssertionInterface
      *
      * @throws MalformedPageElementReferenceException
      * @throws UnknownPageElementException
      * @throws UnknownPageException
+     * @throws NonRetrievablePageException
      */
-    public function createFromAssertionString(string $assertionString, array $pages): AssertionInterface
-    {
+    public function createFromAssertionString(
+        string $assertionString,
+        PageCollectionInterface $pageCollection
+    ): AssertionInterface {
         $identifierString = $this->identifierStringExtractor->extractFromStart($assertionString);
 
-        $identifier = $this->identifierFactory->create($identifierString, $pages);
+        $identifier = $this->identifierFactory->create($identifierString, $pageCollection);
         $value = null;
 
         $comparisonAndValue = trim(mb_substr($assertionString, mb_strlen($identifierString)));

--- a/src/Factory/AssertionFactory.php
+++ b/src/Factory/AssertionFactory.php
@@ -27,7 +27,7 @@ class AssertionFactory
 
     /**
      * @param string $assertionString
-     * @param PageCollectionInterface $pageCollection
+     * @param PageCollectionInterface $pages
      *
      * @return AssertionInterface
      *
@@ -38,11 +38,11 @@ class AssertionFactory
      */
     public function createFromAssertionString(
         string $assertionString,
-        PageCollectionInterface $pageCollection
+        PageCollectionInterface $pages
     ): AssertionInterface {
         $identifierString = $this->identifierStringExtractor->extractFromStart($assertionString);
 
-        $identifier = $this->identifierFactory->create($identifierString, $pageCollection);
+        $identifier = $this->identifierFactory->create($identifierString, $pages);
         $value = null;
 
         $comparisonAndValue = trim(mb_substr($assertionString, mb_strlen($identifierString)));

--- a/src/Factory/AssertionFactory.php
+++ b/src/Factory/AssertionFactory.php
@@ -2,10 +2,14 @@
 
 namespace webignition\BasilParser\Factory;
 
+use webignition\BasilParser\Exception\InvalidPageElementReferenceException;
+use webignition\BasilParser\Exception\UnknownPageElementException;
+use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\IdentifierStringExtractor\IdentifierStringExtractor;
 use webignition\BasilParser\Model\Assertion\Assertion;
 use webignition\BasilParser\Model\Assertion\AssertionComparisons;
 use webignition\BasilParser\Model\Assertion\AssertionInterface;
+use webignition\BasilParser\Model\Page\PageInterface;
 
 class AssertionFactory
 {
@@ -20,11 +24,21 @@ class AssertionFactory
         $this->identifierStringExtractor = new IdentifierStringExtractor();
     }
 
-    public function createFromAssertionString(string $assertionString): AssertionInterface
+    /**
+     * @param string $assertionString
+     * @param PageInterface[] $pages
+     *
+     * @return AssertionInterface
+     *
+     * @throws InvalidPageElementReferenceException
+     * @throws UnknownPageElementException
+     * @throws UnknownPageException
+     */
+    public function createFromAssertionString(string $assertionString, array $pages): AssertionInterface
     {
         $identifierString = $this->identifierStringExtractor->extractFromStart($assertionString);
 
-        $identifier = $this->identifierFactory->create($identifierString);
+        $identifier = $this->identifierFactory->create($identifierString, $pages);
         $value = null;
 
         $comparisonAndValue = trim(mb_substr($assertionString, mb_strlen($identifierString)));

--- a/src/Factory/IdentifierFactory.php
+++ b/src/Factory/IdentifierFactory.php
@@ -76,7 +76,7 @@ class IdentifierFactory
      * @throws UnknownPageException
      * @throws UnknownPageElementException
      */
-    public function create(string $identifierString, array $pages = [], ?string $name = null): ?IdentifierInterface
+    public function create(string $identifierString, array $pages, ?string $name = null): ?IdentifierInterface
     {
         $identifierString = trim($identifierString);
 

--- a/src/Factory/IdentifierFactory.php
+++ b/src/Factory/IdentifierFactory.php
@@ -70,7 +70,7 @@ class IdentifierFactory
 
     /**
      * @param string $identifierString
-     * @param PageCollectionInterface $pageCollection
+     * @param PageCollectionInterface $pages
      * @param string|null $name
      *
      * @return IdentifierInterface|null
@@ -82,7 +82,7 @@ class IdentifierFactory
      */
     public function create(
         string $identifierString,
-        PageCollectionInterface $pageCollection,
+        PageCollectionInterface $pages,
         ?string $name = null
     ): ?IdentifierInterface {
         $identifierString = trim($identifierString);
@@ -109,7 +109,7 @@ class IdentifierFactory
 
             $importName = $pageElementReference->getImportName();
 
-            $page = $pageCollection->findPage($importName);
+            $page = $pages->findPage($importName);
             $elementName = $pageElementReference->getElementName();
             $pageElementIdentifier = $page->getElementIdentifier($elementName);
 

--- a/src/Factory/IdentifierFactory.php
+++ b/src/Factory/IdentifierFactory.php
@@ -2,7 +2,7 @@
 
 namespace webignition\BasilParser\Factory;
 
-use webignition\BasilParser\Exception\InvalidPageElementReferenceException;
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Model\Identifier\Identifier;
@@ -33,7 +33,7 @@ class IdentifierFactory
      *
      * @return IdentifierInterface|null
      *
-     * @throws InvalidPageElementReferenceException
+     * @throws MalformedPageElementReferenceException
      * @throws UnknownPageElementException
      * @throws UnknownPageException
      */
@@ -72,7 +72,7 @@ class IdentifierFactory
      *
      * @return IdentifierInterface|null
      *
-     * @throws InvalidPageElementReferenceException
+     * @throws MalformedPageElementReferenceException
      * @throws UnknownPageException
      * @throws UnknownPageElementException
      */
@@ -97,7 +97,7 @@ class IdentifierFactory
             $pageElementReference = new PageElementReference($identifierString);
 
             if (!$pageElementReference->isValid()) {
-                throw new InvalidPageElementReferenceException($pageElementReference);
+                throw new MalformedPageElementReferenceException($pageElementReference);
             }
 
             $importName = $pageElementReference->getImportName();

--- a/src/Factory/PageFactory.php
+++ b/src/Factory/PageFactory.php
@@ -3,6 +3,11 @@
 namespace webignition\BasilParser\Factory;
 
 use Nyholm\Psr7\Uri;
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\NonRetrievablePageException;
+use webignition\BasilParser\Exception\UnknownPageElementException;
+use webignition\BasilParser\Exception\UnknownPageException;
+use webignition\BasilParser\Model\Identifier\IdentifierInterface;
 use webignition\BasilParser\Model\Page\Page;
 use webignition\BasilParser\Model\Page\PageInterface;
 
@@ -21,6 +26,16 @@ class PageFactory
         $this->identifierFactory = new IdentifierFactory();
     }
 
+    /**
+     * @param array $pageData
+     *
+     * @return PageInterface
+     *
+     * @throws MalformedPageElementReferenceException
+     * @throws NonRetrievablePageException
+     * @throws UnknownPageElementException
+     * @throws UnknownPageException
+     */
     public function createFromPageData(array $pageData): PageInterface
     {
         $uriString = $pageData[self::KEY_URL] ?? '';
@@ -28,6 +43,7 @@ class PageFactory
         $elementsData = is_array($elementsData) ? $elementsData : [];
 
         $uri = new Uri($uriString);
+
         $elementIdentifiers = [];
 
         foreach ($elementsData as $elementName => $identifierString) {
@@ -36,7 +52,10 @@ class PageFactory
                 $elementName,
                 $elementIdentifiers
             );
-            $elementIdentifiers[$elementName] = $identifier;
+
+            if ($identifier instanceof IdentifierInterface) {
+                $elementIdentifiers[$elementName] = $identifier;
+            }
         }
 
         return new Page($uri, $elementIdentifiers);

--- a/src/Factory/StepFactory.php
+++ b/src/Factory/StepFactory.php
@@ -3,12 +3,13 @@
 namespace webignition\BasilParser\Factory;
 
 use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\NonRetrievablePageException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\Action\ActionFactory;
-use webignition\BasilParser\Model\Page\PageInterface;
 use webignition\BasilParser\Model\Step\Step;
 use webignition\BasilParser\Model\Step\StepInterface;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
 
 class StepFactory
 {
@@ -33,15 +34,16 @@ class StepFactory
 
     /**
      * @param array $stepData
-     * @param PageInterface[] $pages
+     * @param PageCollectionInterface $pages
      *
      * @return StepInterface
      *
      * @throws MalformedPageElementReferenceException
      * @throws UnknownPageElementException
      * @throws UnknownPageException
+     * @throws NonRetrievablePageException
      */
-    public function createFromStepData(array $stepData, array $pages): StepInterface
+    public function createFromStepData(array $stepData, PageCollectionInterface $pages): StepInterface
     {
         $actionStrings = $stepData[self::KEY_ACTIONS] ?? [];
         $assertionStrings = $stepData[self::KEY_ASSERTIONS] ?? [];

--- a/src/Factory/StepFactory.php
+++ b/src/Factory/StepFactory.php
@@ -2,7 +2,11 @@
 
 namespace webignition\BasilParser\Factory;
 
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\UnknownPageElementException;
+use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\Action\ActionFactory;
+use webignition\BasilParser\Model\Page\PageInterface;
 use webignition\BasilParser\Model\Step\Step;
 use webignition\BasilParser\Model\Step\StepInterface;
 
@@ -27,7 +31,17 @@ class StepFactory
         $this->assertionFactory = new AssertionFactory();
     }
 
-    public function createFromStepData(array $stepData): StepInterface
+    /**
+     * @param array $stepData
+     * @param PageInterface[] $pages
+     *
+     * @return StepInterface
+     *
+     * @throws MalformedPageElementReferenceException
+     * @throws UnknownPageElementException
+     * @throws UnknownPageException
+     */
+    public function createFromStepData(array $stepData, array $pages): StepInterface
     {
         $actionStrings = $stepData[self::KEY_ACTIONS] ?? [];
         $assertionStrings = $stepData[self::KEY_ASSERTIONS] ?? [];
@@ -41,7 +55,7 @@ class StepFactory
                 $actionString = trim($actionString);
 
                 if ('' !== $actionString) {
-                    $actions[] = $this->actionFactory->createFromActionString($actionString);
+                    $actions[] = $this->actionFactory->createFromActionString($actionString, $pages);
                 }
             }
         }
@@ -52,7 +66,7 @@ class StepFactory
                 $assertionString = trim($assertionString);
 
                 if ('' !== $assertionString) {
-                    $assertions[] = $this->assertionFactory->createFromAssertionString($assertionString);
+                    $assertions[] = $this->assertionFactory->createFromAssertionString($assertionString, $pages);
                 }
             }
         }

--- a/src/Factory/Test/TestFactory.php
+++ b/src/Factory/Test/TestFactory.php
@@ -6,14 +6,15 @@ use webignition\BasilParser\Builder\StepBuilder;
 use webignition\BasilParser\Builder\StepBuilderInvalidPageElementReferenceException;
 use webignition\BasilParser\Builder\StepBuilderUnknownDataProviderImportException;
 use webignition\BasilParser\Builder\StepBuilderUnknownPageElementException;
-use webignition\BasilParser\Builder\StepBuilderUnknownPageImportException;
 use webignition\BasilParser\Builder\StepBuilderUnknownStepImportException;
 use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\NonRetrievablePageException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Loader\PageLoader;
 use webignition\BasilParser\Loader\YamlLoaderException;
 use webignition\BasilParser\Model\Test\Test;
+use webignition\BasilParser\PageCollection\DeferredPageCollection;
 
 class TestFactory
 {
@@ -45,12 +46,12 @@ class TestFactory
      * @throws StepBuilderInvalidPageElementReferenceException
      * @throws StepBuilderUnknownDataProviderImportException
      * @throws StepBuilderUnknownPageElementException
-     * @throws StepBuilderUnknownPageImportException
      * @throws StepBuilderUnknownStepImportException
      * @throws MalformedPageElementReferenceException
      * @throws UnknownPageElementException
      * @throws UnknownPageException
      * @throws YamlLoaderException
+     * @throws NonRetrievablePageException
      */
     public function createFromTestData(array $testData)
     {
@@ -69,6 +70,8 @@ class TestFactory
         $configuration = $this->configurationFactory->createFromConfigurationData($configurationData);
         $steps = [];
 
+        $pages = new DeferredPageCollection($this->pageLoader, $pageImportPaths);
+
         foreach ($stepNames as $stepName) {
             $stepData = $testData[$stepName];
 
@@ -76,8 +79,8 @@ class TestFactory
                 $stepName,
                 $stepData,
                 $stepImportPaths,
-                $pageImportPaths,
-                $dataProviderImportPaths
+                $dataProviderImportPaths,
+                $pages
             );
 
             $steps[$stepName] = $step;

--- a/src/Factory/Test/TestFactory.php
+++ b/src/Factory/Test/TestFactory.php
@@ -3,6 +3,16 @@
 namespace webignition\BasilParser\Factory\Test;
 
 use webignition\BasilParser\Builder\StepBuilder;
+use webignition\BasilParser\Builder\StepBuilderInvalidPageElementReferenceException;
+use webignition\BasilParser\Builder\StepBuilderUnknownDataProviderImportException;
+use webignition\BasilParser\Builder\StepBuilderUnknownPageElementException;
+use webignition\BasilParser\Builder\StepBuilderUnknownPageImportException;
+use webignition\BasilParser\Builder\StepBuilderUnknownStepImportException;
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\UnknownPageElementException;
+use webignition\BasilParser\Exception\UnknownPageException;
+use webignition\BasilParser\Loader\PageLoader;
+use webignition\BasilParser\Loader\YamlLoaderException;
 use webignition\BasilParser\Model\Test\Test;
 
 class TestFactory
@@ -16,14 +26,32 @@ class TestFactory
     const KEY_TEST_DATA = 'data';
 
     private $configurationFactory;
+    private $pageLoader;
     private $stepBuilder;
 
-    public function __construct(ConfigurationFactory $configurationFactory, StepBuilder $stepBuilder)
-    {
+    public function __construct(
+        ConfigurationFactory $configurationFactory,
+        PageLoader $pageLoader,
+        StepBuilder $stepBuilder
+    ) {
         $this->configurationFactory = $configurationFactory;
+        $this->pageLoader = $pageLoader;
         $this->stepBuilder = $stepBuilder;
     }
 
+    /**
+     * @param array $testData
+     * @return Test
+     * @throws StepBuilderInvalidPageElementReferenceException
+     * @throws StepBuilderUnknownDataProviderImportException
+     * @throws StepBuilderUnknownPageElementException
+     * @throws StepBuilderUnknownPageImportException
+     * @throws StepBuilderUnknownStepImportException
+     * @throws MalformedPageElementReferenceException
+     * @throws UnknownPageElementException
+     * @throws UnknownPageException
+     * @throws YamlLoaderException
+     */
     public function createFromTestData(array $testData)
     {
         $configurationData = $testData[self::KEY_CONFIGURATION] ?? [];

--- a/src/Loader/DataSetLoader.php
+++ b/src/Loader/DataSetLoader.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace webignition\BasilParser\Loader;
+
+use webignition\BasilParser\Model\DataSet\DataSet;
+
+class DataSetLoader
+{
+    private $yamlLoader;
+
+    public function __construct(YamlLoader $yamlLoader)
+    {
+        $this->yamlLoader = $yamlLoader;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return DataSet[]
+     *
+     * @throws YamlLoaderException
+     */
+    public function load(string $path): array
+    {
+        $data = $this->yamlLoader->loadArray($path);
+
+        $dataSets = [];
+
+        foreach ($data as $dataSetData) {
+            if (is_array($dataSetData)) {
+                $dataSets[] = new DataSet($dataSetData);
+            }
+        }
+
+        return $dataSets;
+    }
+}

--- a/src/Loader/StepLoader.php
+++ b/src/Loader/StepLoader.php
@@ -3,10 +3,12 @@
 namespace webignition\BasilParser\Loader;
 
 use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\NonRetrievablePageException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\StepFactory;
 use webignition\BasilParser\Model\Step\StepInterface;
+use webignition\BasilParser\PageCollection\EmptyPageCollection;
 
 class StepLoader
 {
@@ -28,11 +30,12 @@ class StepLoader
      * @throws MalformedPageElementReferenceException
      * @throws UnknownPageElementException
      * @throws UnknownPageException
+     * @throws NonRetrievablePageException
      */
     public function load(string $path): StepInterface
     {
         $data = $this->yamlLoader->loadArray($path);
 
-        return $this->stepFactory->createFromStepData($data, []);
+        return $this->stepFactory->createFromStepData($data, new EmptyPageCollection());
     }
 }

--- a/src/Loader/StepLoader.php
+++ b/src/Loader/StepLoader.php
@@ -2,6 +2,9 @@
 
 namespace webignition\BasilParser\Loader;
 
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\UnknownPageElementException;
+use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\StepFactory;
 use webignition\BasilParser\Model\Step\StepInterface;
 
@@ -22,11 +25,14 @@ class StepLoader
      * @return StepInterface
      *
      * @throws YamlLoaderException
+     * @throws MalformedPageElementReferenceException
+     * @throws UnknownPageElementException
+     * @throws UnknownPageException
      */
     public function load(string $path): StepInterface
     {
         $data = $this->yamlLoader->loadArray($path);
 
-        return $this->stepFactory->createFromStepData($data);
+        return $this->stepFactory->createFromStepData($data, []);
     }
 }

--- a/src/Model/PageElementReference/PageElementReference.php
+++ b/src/Model/PageElementReference/PageElementReference.php
@@ -47,4 +47,9 @@ class PageElementReference implements PageElementReferenceInterface
     {
         return $this->isValid;
     }
+
+    public function __toString(): string
+    {
+        return $this->reference;
+    }
 }

--- a/src/Model/PageElementReference/PageElementReferenceInterface.php
+++ b/src/Model/PageElementReference/PageElementReferenceInterface.php
@@ -7,4 +7,5 @@ interface PageElementReferenceInterface
     public function getImportName(): string;
     public function getElementName(): string;
     public function isValid(): bool;
+    public function __toString(): string;
 }

--- a/src/PageCollection/DeferredPageCollection.php
+++ b/src/PageCollection/DeferredPageCollection.php
@@ -8,7 +8,7 @@ use webignition\BasilParser\Loader\PageLoader;
 use webignition\BasilParser\Loader\YamlLoaderException;
 use webignition\BasilParser\Model\Page\PageInterface;
 
-class PageCollection implements PageCollectionInterface
+class DeferredPageCollection implements PageCollectionInterface
 {
     private $pageLoader;
     private $importPaths;

--- a/src/PageCollection/EmptyPageCollection.php
+++ b/src/PageCollection/EmptyPageCollection.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace webignition\BasilParser\PageCollection;
+
+use webignition\BasilParser\Exception\UnknownPageException;
+use webignition\BasilParser\Model\Page\PageInterface;
+
+class EmptyPageCollection implements PageCollectionInterface
+{
+    /**
+     * @param string $importName
+     *
+     * @return PageInterface
+     *
+     * @throws UnknownPageException
+     */
+    public function findPage(string $importName): PageInterface
+    {
+        throw new UnknownPageException($importName);
+    }
+}

--- a/src/PageCollection/PageCollection.php
+++ b/src/PageCollection/PageCollection.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace webignition\BasilParser\PageCollection;
+
+use webignition\BasilParser\Exception\NonRetrievablePageException;
+use webignition\BasilParser\Exception\UnknownPageException;
+use webignition\BasilParser\Loader\PageLoader;
+use webignition\BasilParser\Loader\YamlLoaderException;
+use webignition\BasilParser\Model\Page\PageInterface;
+
+class PageCollection implements PageCollectionInterface
+{
+    private $pageLoader;
+    private $importPaths;
+    private $pages = [];
+
+    public function __construct(PageLoader $pageLoader, array $importPaths)
+    {
+        $this->pageLoader = $pageLoader;
+        $this->importPaths = $importPaths;
+    }
+
+    /**
+     * @param string $importName
+     *
+     * @return PageInterface
+     *
+     * @throws NonRetrievablePageException
+     * @throws UnknownPageException
+     */
+    public function findPage(string $importName): PageInterface
+    {
+        $page = $this->pages[$importName] ?? null;
+
+        if (null === $page) {
+            $page = $this->retrievePage($importName);
+            $this->pages[$importName] = $page;
+        }
+
+        return $page;
+    }
+
+    /**
+     * @param string $importName
+     *
+     * @return PageInterface
+     *
+     * @throws NonRetrievablePageException
+     * @throws UnknownPageException
+     */
+    private function retrievePage(string $importName): PageInterface
+    {
+        $importPath = $this->importPaths[$importName] ?? null;
+
+        if (null === $importPath) {
+            throw new UnknownPageException($importName);
+        }
+
+        try {
+            return $this->pageLoader->load($importPath);
+        } catch (YamlLoaderException $yamlLoaderException) {
+            throw new NonRetrievablePageException($importName, $importPath, $yamlLoaderException);
+        }
+    }
+}

--- a/src/PageCollection/PageCollectionInterface.php
+++ b/src/PageCollection/PageCollectionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace webignition\BasilParser\PageCollection;
+
+use webignition\BasilParser\Exception\NonRetrievablePageException;
+use webignition\BasilParser\Exception\UnknownPageException;
+use webignition\BasilParser\Model\Page\PageInterface;
+
+interface PageCollectionInterface
+{
+    /**
+     * @param string $importName
+     *
+     * @return PageInterface
+     *
+     * @throws UnknownPageException
+     * @throws NonRetrievablePageException
+     */
+    public function findPage(string $importName): PageInterface;
+}

--- a/src/PageCollection/PopulatedPageCollection.php
+++ b/src/PageCollection/PopulatedPageCollection.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace webignition\BasilParser\PageCollection;
+
+use webignition\BasilParser\Exception\UnknownPageException;
+use webignition\BasilParser\Model\Page\PageInterface;
+
+class PopulatedPageCollection implements PageCollectionInterface
+{
+    private $pages = [];
+
+    public function __construct(array $pages)
+    {
+        foreach ($pages as $importName => $page) {
+            if ($page instanceof PageInterface) {
+                $this->pages[$importName] = $page;
+            }
+        }
+    }
+
+    /**
+     * @param string $importName
+     *
+     * @return PageInterface
+     *
+     * @throws UnknownPageException
+     */
+    public function findPage(string $importName): PageInterface
+    {
+        $page = $this->pages[$importName] ?? null;
+
+        if (null === $page) {
+            throw new UnknownPageException($importName);
+        }
+
+        return $page;
+    }
+}

--- a/tests/Fixtures/Page/example.com.button.heading.yml
+++ b/tests/Fixtures/Page/example.com.button.heading.yml
@@ -1,0 +1,4 @@
+url: https://example.com
+elements:
+  button: "\".button\""
+  heading: "\".heading\""

--- a/tests/Unit/Builder/StepBuilderTest.php
+++ b/tests/Unit/Builder/StepBuilderTest.php
@@ -13,6 +13,7 @@ use webignition\BasilParser\Builder\StepBuilderUnknownPageElementException;
 use webignition\BasilParser\Builder\StepBuilderUnknownStepImportException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\StepFactory;
+use webignition\BasilParser\Loader\DataSetLoader;
 use webignition\BasilParser\Loader\StepLoader;
 use webignition\BasilParser\Loader\YamlLoader;
 use webignition\BasilParser\Model\Action\ActionTypes;
@@ -20,6 +21,7 @@ use webignition\BasilParser\Model\Action\InputAction;
 use webignition\BasilParser\Model\Action\InteractionAction;
 use webignition\BasilParser\Model\Assertion\Assertion;
 use webignition\BasilParser\Model\Assertion\AssertionComparisons;
+use webignition\BasilParser\Model\DataSet\DataSet;
 use webignition\BasilParser\Model\Identifier\Identifier;
 use webignition\BasilParser\Model\Identifier\IdentifierTypes;
 use webignition\BasilParser\Model\Page\Page;
@@ -49,7 +51,9 @@ class StepBuilderTest extends \PHPUnit\Framework\TestCase
         $yamlLoader = new YamlLoader($yamlParser);
         $stepLoader = new StepLoader($yamlLoader, $stepFactory);
 
-        $this->stepBuilder = new StepBuilder($stepFactory, $stepLoader, $yamlLoader);
+        $dataSetLoader = new DataSetLoader($yamlLoader);
+
+        $this->stepBuilder = new StepBuilder($stepFactory, $stepLoader, $dataSetLoader);
     }
 
     /**
@@ -291,7 +295,7 @@ class StepBuilderTest extends \PHPUnit\Framework\TestCase
                     'data_provider_name' => FixturePathFinder::find('DataProvider/expected-title-only.yml'),
                 ],
                 'pages' => new EmptyPageCollection(),
-                'expectedStep' => new Step(
+                'expectedStep' => (new Step(
                     [
                         new InteractionAction(
                             ActionTypes::CLICK,
@@ -316,7 +320,14 @@ class StepBuilderTest extends \PHPUnit\Framework\TestCase
                             )
                         ),
                     ]
-                ),
+                ))->withDataSets([
+                    new DataSet([
+                        'expected_title' => 'Foo',
+                    ]),
+                    new DataSet([
+                        'expected_title' => 'Bar',
+                    ]),
+                ]),
             ],
             'element parameters' => [
                 'stepData' => [

--- a/tests/Unit/Factory/Action/ActionFactoryTest.php
+++ b/tests/Unit/Factory/Action/ActionFactoryTest.php
@@ -19,6 +19,9 @@ use webignition\BasilParser\Model\Identifier\IdentifierTypes;
 use webignition\BasilParser\Model\Page\Page;
 use webignition\BasilParser\Model\Value\Value;
 use webignition\BasilParser\Model\Value\ValueTypes;
+use webignition\BasilParser\PageCollection\EmptyPageCollection;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
+use webignition\BasilParser\PageCollection\PopulatedPageCollection;
 
 class ActionFactoryTest extends \PHPUnit\Framework\TestCase
 {
@@ -41,7 +44,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateFromActionStringForInteractionAction(
         string $actionString,
-        array $pages,
+        PageCollectionInterface $pages,
         InteractionAction $expectedAction
     ) {
         $action = $this->actionFactory->createFromActionString($actionString, $pages);
@@ -54,7 +57,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'click css selector with null position double-quoted' => [
                 'actionString' => 'click ".sign-in-form .submit-button"',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     new Identifier(
@@ -66,7 +69,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'click css selector with position double-quoted' => [
                 'actionString' => 'click ".sign-in-form .submit-button":3',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     new Identifier(
@@ -79,7 +82,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'click page model reference' => [
                 'actionString' => 'click page_import_name.elements.element_name',
-                'pages' => [
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(
                         new Uri('http://example.com'),
                         [
@@ -89,7 +92,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
                             )
                         ]
                     ),
-                ],
+                ]),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     new Identifier(
@@ -101,7 +104,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'click element parameter reference' => [
                 'actionString' => 'click $elements.name',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     new Identifier(
@@ -113,7 +116,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'click with no arguments' => [
                 'actionString' => 'click',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     null,
@@ -128,7 +131,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'submit css selector with null position double-quoted' => [
                 'actionString' => 'submit ".sign-in-form"',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     new Identifier(
@@ -140,7 +143,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'submit css selector with position double-quoted' => [
                 'actionString' => 'submit ".sign-in-form":3',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     new Identifier(
@@ -153,7 +156,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'submit page model reference' => [
                 'actionString' => 'submit page_import_name.elements.element_name',
-                'pages' => [
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(
                         new Uri('http://example.com'),
                         [
@@ -163,7 +166,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
                             )
                         ]
                     ),
-                ],
+                ]),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     new Identifier(
@@ -175,7 +178,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'submit element parameter reference' => [
                 'actionString' => 'submit $elements.name',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     new Identifier(
@@ -187,7 +190,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'submit no arguments' => [
                 'actionString' => 'submit',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     null,
@@ -202,7 +205,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'wait-for css selector with null position double-quoted' => [
                 'actionString' => 'wait-for ".sign-in-form .submit-button"',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     new Identifier(
@@ -214,7 +217,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'wait-for css selector with position double-quoted' => [
                 'actionString' => 'wait-for ".sign-in-form .submit-button":3',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     new Identifier(
@@ -227,7 +230,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'wait-for page model reference' => [
                 'actionString' => 'wait-for page_import_name.elements.element_name',
-                'pages' => [
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(
                         new Uri('http://example.com'),
                         [
@@ -237,7 +240,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
                             )
                         ]
                     ),
-                ],
+                ]),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     new Identifier(
@@ -249,7 +252,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'wait-for element parameter reference' => [
                 'actionString' => 'wait-for $elements.name',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     new Identifier(
@@ -261,7 +264,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'wait-for no arguments' => [
                 'actionString' => 'wait-for',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     null,
@@ -276,7 +279,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateFromActionStringForWaitAction(string $actionString, WaitAction $expectedAction)
     {
-        $action = $this->actionFactory->createFromActionString($actionString);
+        $action = $this->actionFactory->createFromActionString($actionString, new EmptyPageCollection());
 
         $this->assertEquals($expectedAction, $action);
     }
@@ -310,7 +313,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
         string $actionString,
         NoArgumentsAction $expectedAction
     ) {
-        $action = $this->actionFactory->createFromActionString($actionString);
+        $action = $this->actionFactory->createFromActionString($actionString, new EmptyPageCollection());
 
         $this->assertEquals($expectedAction, $action);
     }
@@ -338,7 +341,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateFromActionStringForInputAction(string $actionString, InputAction $expectedAction)
     {
-        $action = $this->actionFactory->createFromActionString($actionString);
+        $action = $this->actionFactory->createFromActionString($actionString, new EmptyPageCollection());
 
         $this->assertEquals($expectedAction, $action);
     }
@@ -509,7 +512,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $actionString = 'foo ".selector" to "value';
 
-        $action = $this->actionFactory->createFromActionString($actionString);
+        $action = $this->actionFactory->createFromActionString($actionString, new EmptyPageCollection());
 
         $this->assertInstanceOf(UnrecognisedAction::class, $action);
         $this->assertSame('foo', $action->getType());
@@ -520,7 +523,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $actionString = '';
 
-        $action = $this->actionFactory->createFromActionString($actionString);
+        $action = $this->actionFactory->createFromActionString($actionString, new EmptyPageCollection());
 
         $this->assertInstanceOf(UnrecognisedAction::class, $action);
         $this->assertSame('', $action->getType());
@@ -532,7 +535,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateFromActionStringThrowsPageElementException(
         string $actionString,
-        array $pages,
+        PageCollectionInterface $pages,
         string $expectedException,
         string $expectedExceptionMessage
     ) {
@@ -547,99 +550,99 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'click malformed page element reference' => [
                 'actionString' => 'click invalid-page-element-reference',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => MalformedPageElementReferenceException::class,
                 'expectedExceptionMessage' => 'Malformed page element reference "invalid-page-element-reference"',
             ],
             'click action unknown page' => [
                 'actionString' => 'click page_import_name.elements.element_name',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => UnknownPageException::class,
                 'expectedExceptionMessage' => 'Unknown page "page_import_name',
             ],
             'click action unknown page element' => [
                 'actionString' => 'click page_import_name.elements.element_name',
-                'pages' => [
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(new Uri('http://example.com'), []),
-                ],
+                ]),
                 'expectedException' => UnknownPageElementException::class,
                 'expectedExceptionMessage' => 'Unknown page element "element_name" in page "page_import_name"',
             ],
             'set malformed page element reference' => [
                 'actionString' => 'set invalid-page-element-reference to "value"',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => MalformedPageElementReferenceException::class,
                 'expectedExceptionMessage' => 'Malformed page element reference "invalid-page-element-reference"',
             ],
             'set action unknown page' => [
                 'actionString' => 'set page_import_name.elements.element_name to "value"',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => UnknownPageException::class,
                 'expectedExceptionMessage' => 'Unknown page "page_import_name',
             ],
             'set action unknown page element' => [
                 'actionString' => 'set page_import_name.elements.element_name to "value"',
-                'pages' => [
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(new Uri('http://example.com'), []),
-                ],
+                ]),
                 'expectedException' => UnknownPageElementException::class,
                 'expectedExceptionMessage' => 'Unknown page element "element_name" in page "page_import_name"',
             ],
             'submit malformed page element reference' => [
                 'actionString' => 'submit invalid-page-element-reference',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => MalformedPageElementReferenceException::class,
                 'expectedExceptionMessage' => 'Malformed page element reference "invalid-page-element-reference"',
             ],
             'submit action unknown page' => [
                 'actionString' => 'submit page_import_name.elements.element_name',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => UnknownPageException::class,
                 'expectedExceptionMessage' => 'Unknown page "page_import_name',
             ],
             'submit action unknown page element' => [
                 'actionString' => 'submit page_import_name.elements.element_name',
-                'pages' => [
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(new Uri('http://example.com'), []),
-                ],
+                ]),
                 'expectedException' => UnknownPageElementException::class,
                 'expectedExceptionMessage' => 'Unknown page element "element_name" in page "page_import_name"',
             ],
             'wait-for malformed page element reference' => [
                 'actionString' => 'wait-for invalid-page-element-reference',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => MalformedPageElementReferenceException::class,
                 'expectedExceptionMessage' => 'Malformed page element reference "invalid-page-element-reference"',
             ],
             'wait-for action unknown page' => [
                 'actionString' => 'wait-for page_import_name.elements.element_name',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => UnknownPageException::class,
                 'expectedExceptionMessage' => 'Unknown page "page_import_name',
             ],
             'wait-for action unknown page element' => [
                 'actionString' => 'wait-for page_import_name.elements.element_name',
-                'pages' => [
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(new Uri('http://example.com'), []),
-                ],
+                ]),
                 'expectedException' => UnknownPageElementException::class,
                 'expectedExceptionMessage' => 'Unknown page element "element_name" in page "page_import_name"',
             ],
             'click css selector unquoted is treated as page model element reference' => [
                 'actionString' => 'click .sign-in-form .submit-button',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => MalformedPageElementReferenceException::class,
                 'expectedExceptionMessage' => 'Malformed page element reference ".sign-in-form .submit-button"',
             ],
             'submit css selector unquoted is treated as page model element reference' => [
                 'actionString' => 'submit .sign-in-form',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => MalformedPageElementReferenceException::class,
                 'expectedExceptionMessage' => 'Malformed page element reference ".sign-in-form"',
             ],
             'wait-for css selector unquoted is treated as page model element reference' => [
                 'actionString' => 'wait-for .sign-in-form .submit-button',
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedException' => MalformedPageElementReferenceException::class,
                 'expectedExceptionMessage' => 'Malformed page element reference ".sign-in-form .submit-button"',
             ],

--- a/tests/Unit/Factory/Action/ActionFactoryTest.php
+++ b/tests/Unit/Factory/Action/ActionFactoryTest.php
@@ -3,6 +3,10 @@
 
 namespace webignition\BasilParser\Tests\Unit\Factory\Action;
 
+use Nyholm\Psr7\Uri;
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
+use webignition\BasilParser\Exception\UnknownPageElementException;
+use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\Action\ActionFactory;
 use webignition\BasilParser\Model\Action\ActionTypes;
 use webignition\BasilParser\Model\Action\InputAction;
@@ -12,6 +16,7 @@ use webignition\BasilParser\Model\Action\UnrecognisedAction;
 use webignition\BasilParser\Model\Action\WaitAction;
 use webignition\BasilParser\Model\Identifier\Identifier;
 use webignition\BasilParser\Model\Identifier\IdentifierTypes;
+use webignition\BasilParser\Model\Page\Page;
 use webignition\BasilParser\Model\Value\Value;
 use webignition\BasilParser\Model\Value\ValueTypes;
 
@@ -36,9 +41,10 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateFromActionStringForInteractionAction(
         string $actionString,
+        array $pages,
         InteractionAction $expectedAction
     ) {
-        $action = $this->actionFactory->createFromActionString($actionString);
+        $action = $this->actionFactory->createFromActionString($actionString, $pages);
 
         $this->assertEquals($expectedAction, $action);
     }
@@ -48,6 +54,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'click css selector with null position double-quoted' => [
                 'actionString' => 'click ".sign-in-form .submit-button"',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     new Identifier(
@@ -59,6 +66,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'click css selector with position double-quoted' => [
                 'actionString' => 'click ".sign-in-form .submit-button":3',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     new Identifier(
@@ -69,30 +77,31 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
                     '".sign-in-form .submit-button":3'
                 ),
             ],
-            'click css selector unquoted is treated as page model element reference' => [
-                'actionString' => 'click .sign-in-form .submit-button',
-                'expectedAction' => new InteractionAction(
-                    ActionTypes::CLICK,
-                    new Identifier(
-                        IdentifierTypes::PAGE_MODEL_ELEMENT_REFERENCE,
-                        '.sign-in-form .submit-button'
-                    ),
-                    '.sign-in-form .submit-button'
-                ),
-            ],
             'click page model reference' => [
-                'actionString' => 'click imported_page_model.elements.element_name',
+                'actionString' => 'click page_import_name.elements.element_name',
+                'pages' => [
+                    'page_import_name' => new Page(
+                        new Uri('http://example.com'),
+                        [
+                            'element_name' => new Identifier(
+                                IdentifierTypes::CSS_SELECTOR,
+                                '.selector'
+                            )
+                        ]
+                    ),
+                ],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     new Identifier(
-                        IdentifierTypes::PAGE_MODEL_ELEMENT_REFERENCE,
-                        'imported_page_model.elements.element_name'
+                        IdentifierTypes::CSS_SELECTOR,
+                        '.selector'
                     ),
-                    'imported_page_model.elements.element_name'
+                    'page_import_name.elements.element_name'
                 ),
             ],
             'click element parameter reference' => [
                 'actionString' => 'click $elements.name',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     new Identifier(
@@ -104,6 +113,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'click with no arguments' => [
                 'actionString' => 'click',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::CLICK,
                     null,
@@ -118,6 +128,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'submit css selector with null position double-quoted' => [
                 'actionString' => 'submit ".sign-in-form"',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     new Identifier(
@@ -129,6 +140,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'submit css selector with position double-quoted' => [
                 'actionString' => 'submit ".sign-in-form":3',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     new Identifier(
@@ -139,30 +151,31 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
                     '".sign-in-form":3'
                 ),
             ],
-            'submit css selector unquoted is treated as page model element reference' => [
-                'actionString' => 'submit .sign-in-form',
-                'expectedAction' => new InteractionAction(
-                    ActionTypes::SUBMIT,
-                    new Identifier(
-                        IdentifierTypes::PAGE_MODEL_ELEMENT_REFERENCE,
-                        '.sign-in-form'
-                    ),
-                    '.sign-in-form'
-                ),
-            ],
             'submit page model reference' => [
-                'actionString' => 'submit imported_page_model.elements.element_name',
+                'actionString' => 'submit page_import_name.elements.element_name',
+                'pages' => [
+                    'page_import_name' => new Page(
+                        new Uri('http://example.com'),
+                        [
+                            'element_name' => new Identifier(
+                                IdentifierTypes::CSS_SELECTOR,
+                                '.selector'
+                            )
+                        ]
+                    ),
+                ],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     new Identifier(
-                        IdentifierTypes::PAGE_MODEL_ELEMENT_REFERENCE,
-                        'imported_page_model.elements.element_name'
+                        IdentifierTypes::CSS_SELECTOR,
+                        '.selector'
                     ),
-                    'imported_page_model.elements.element_name'
+                    'page_import_name.elements.element_name'
                 ),
             ],
             'submit element parameter reference' => [
                 'actionString' => 'submit $elements.name',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     new Identifier(
@@ -174,6 +187,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'submit no arguments' => [
                 'actionString' => 'submit',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::SUBMIT,
                     null,
@@ -188,6 +202,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'wait-for css selector with null position double-quoted' => [
                 'actionString' => 'wait-for ".sign-in-form .submit-button"',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     new Identifier(
@@ -199,6 +214,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'wait-for css selector with position double-quoted' => [
                 'actionString' => 'wait-for ".sign-in-form .submit-button":3',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     new Identifier(
@@ -209,30 +225,31 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
                     '".sign-in-form .submit-button":3'
                 ),
             ],
-            'wait-for css selector unquoted is treated as page model element reference' => [
-                'actionString' => 'wait-for .sign-in-form .submit-button',
-                'expectedAction' => new InteractionAction(
-                    ActionTypes::WAIT_FOR,
-                    new Identifier(
-                        IdentifierTypes::PAGE_MODEL_ELEMENT_REFERENCE,
-                        '.sign-in-form .submit-button'
-                    ),
-                    '.sign-in-form .submit-button'
-                ),
-            ],
             'wait-for page model reference' => [
-                'actionString' => 'wait-for imported_page_model.elements.element_name',
+                'actionString' => 'wait-for page_import_name.elements.element_name',
+                'pages' => [
+                    'page_import_name' => new Page(
+                        new Uri('http://example.com'),
+                        [
+                            'element_name' => new Identifier(
+                                IdentifierTypes::CSS_SELECTOR,
+                                '.selector'
+                            )
+                        ]
+                    ),
+                ],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     new Identifier(
-                        IdentifierTypes::PAGE_MODEL_ELEMENT_REFERENCE,
-                        'imported_page_model.elements.element_name'
+                        IdentifierTypes::CSS_SELECTOR,
+                        '.selector'
                     ),
-                    'imported_page_model.elements.element_name'
+                    'page_import_name.elements.element_name'
                 ),
             ],
             'wait-for element parameter reference' => [
                 'actionString' => 'wait-for $elements.name',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     new Identifier(
@@ -244,6 +261,7 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'wait-for no arguments' => [
                 'actionString' => 'wait-for',
+                'pages' => [],
                 'expectedAction' => new InteractionAction(
                     ActionTypes::WAIT_FOR,
                     null,
@@ -507,5 +525,124 @@ class ActionFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(UnrecognisedAction::class, $action);
         $this->assertSame('', $action->getType());
         $this->assertFalse($action->isRecognised());
+    }
+
+    /**
+     * @dataProvider createFromActionStringThrowsPageElementExceptionDataProvider
+     */
+    public function testCreateFromActionStringThrowsPageElementException(
+        string $actionString,
+        array $pages,
+        string $expectedException,
+        string $expectedExceptionMessage
+    ) {
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $this->actionFactory->createFromActionString($actionString, $pages);
+    }
+
+    public function createFromActionStringThrowsPageElementExceptionDataProvider(): array
+    {
+        return [
+            'click malformed page element reference' => [
+                'actionString' => 'click invalid-page-element-reference',
+                'pages' => [],
+                'expectedException' => MalformedPageElementReferenceException::class,
+                'expectedExceptionMessage' => 'Malformed page element reference "invalid-page-element-reference"',
+            ],
+            'click action unknown page' => [
+                'actionString' => 'click page_import_name.elements.element_name',
+                'pages' => [],
+                'expectedException' => UnknownPageException::class,
+                'expectedExceptionMessage' => 'Unknown page "page_import_name',
+            ],
+            'click action unknown page element' => [
+                'actionString' => 'click page_import_name.elements.element_name',
+                'pages' => [
+                    'page_import_name' => new Page(new Uri('http://example.com'), []),
+                ],
+                'expectedException' => UnknownPageElementException::class,
+                'expectedExceptionMessage' => 'Unknown page element "element_name" in page "page_import_name"',
+            ],
+            'set malformed page element reference' => [
+                'actionString' => 'set invalid-page-element-reference to "value"',
+                'pages' => [],
+                'expectedException' => MalformedPageElementReferenceException::class,
+                'expectedExceptionMessage' => 'Malformed page element reference "invalid-page-element-reference"',
+            ],
+            'set action unknown page' => [
+                'actionString' => 'set page_import_name.elements.element_name to "value"',
+                'pages' => [],
+                'expectedException' => UnknownPageException::class,
+                'expectedExceptionMessage' => 'Unknown page "page_import_name',
+            ],
+            'set action unknown page element' => [
+                'actionString' => 'set page_import_name.elements.element_name to "value"',
+                'pages' => [
+                    'page_import_name' => new Page(new Uri('http://example.com'), []),
+                ],
+                'expectedException' => UnknownPageElementException::class,
+                'expectedExceptionMessage' => 'Unknown page element "element_name" in page "page_import_name"',
+            ],
+            'submit malformed page element reference' => [
+                'actionString' => 'submit invalid-page-element-reference',
+                'pages' => [],
+                'expectedException' => MalformedPageElementReferenceException::class,
+                'expectedExceptionMessage' => 'Malformed page element reference "invalid-page-element-reference"',
+            ],
+            'submit action unknown page' => [
+                'actionString' => 'submit page_import_name.elements.element_name',
+                'pages' => [],
+                'expectedException' => UnknownPageException::class,
+                'expectedExceptionMessage' => 'Unknown page "page_import_name',
+            ],
+            'submit action unknown page element' => [
+                'actionString' => 'submit page_import_name.elements.element_name',
+                'pages' => [
+                    'page_import_name' => new Page(new Uri('http://example.com'), []),
+                ],
+                'expectedException' => UnknownPageElementException::class,
+                'expectedExceptionMessage' => 'Unknown page element "element_name" in page "page_import_name"',
+            ],
+            'wait-for malformed page element reference' => [
+                'actionString' => 'wait-for invalid-page-element-reference',
+                'pages' => [],
+                'expectedException' => MalformedPageElementReferenceException::class,
+                'expectedExceptionMessage' => 'Malformed page element reference "invalid-page-element-reference"',
+            ],
+            'wait-for action unknown page' => [
+                'actionString' => 'wait-for page_import_name.elements.element_name',
+                'pages' => [],
+                'expectedException' => UnknownPageException::class,
+                'expectedExceptionMessage' => 'Unknown page "page_import_name',
+            ],
+            'wait-for action unknown page element' => [
+                'actionString' => 'wait-for page_import_name.elements.element_name',
+                'pages' => [
+                    'page_import_name' => new Page(new Uri('http://example.com'), []),
+                ],
+                'expectedException' => UnknownPageElementException::class,
+                'expectedExceptionMessage' => 'Unknown page element "element_name" in page "page_import_name"',
+            ],
+            'click css selector unquoted is treated as page model element reference' => [
+                'actionString' => 'click .sign-in-form .submit-button',
+                'pages' => [],
+                'expectedException' => MalformedPageElementReferenceException::class,
+                'expectedExceptionMessage' => 'Malformed page element reference ".sign-in-form .submit-button"',
+            ],
+            'submit css selector unquoted is treated as page model element reference' => [
+                'actionString' => 'submit .sign-in-form',
+                'pages' => [],
+                'expectedException' => MalformedPageElementReferenceException::class,
+                'expectedExceptionMessage' => 'Malformed page element reference ".sign-in-form"',
+            ],
+            'wait-for css selector unquoted is treated as page model element reference' => [
+                'actionString' => 'wait-for .sign-in-form .submit-button',
+                'pages' => [],
+                'expectedException' => MalformedPageElementReferenceException::class,
+                'expectedExceptionMessage' => 'Malformed page element reference ".sign-in-form .submit-button"',
+            ],
+        ];
     }
 }

--- a/tests/Unit/Factory/AssertionFactoryTest.php
+++ b/tests/Unit/Factory/AssertionFactoryTest.php
@@ -15,6 +15,9 @@ use webignition\BasilParser\Model\Value\ValueTypes;
 use webignition\BasilParser\Model\Identifier\Identifier;
 use webignition\BasilParser\Model\Identifier\IdentifierInterface;
 use webignition\BasilParser\Model\Identifier\IdentifierTypes;
+use webignition\BasilParser\PageCollection\EmptyPageCollection;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
+use webignition\BasilParser\PageCollection\PopulatedPageCollection;
 
 class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
 {
@@ -35,12 +38,12 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateFromAssertionString(
         string $assertionString,
-        array $pages,
+        PageCollectionInterface $pageCollection,
         IdentifierInterface $expectedIdentifier,
         string $expectedComparison,
         ?ValueInterface $expectedValue
     ) {
-        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, $pages);
+        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, $pageCollection);
 
         $this->assertInstanceOf(AssertionInterface::class, $assertion);
         $this->assertSame($assertionString, $assertion->getAssertionString());
@@ -54,7 +57,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'simple css selector, is, scalar value' => [
                 'assertionString' => '".selector" is "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -67,7 +70,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector with element reference, is, scalar value' => [
                 'assertionString' => '"{{ reference }} .selector" is "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '{{ reference }} .selector'
@@ -80,7 +83,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, data parameter value' => [
                 'assertionString' => '".selector" is $data.name',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -93,7 +96,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, element parameter value' => [
                 'actionString' => '".selector" is $elements.name',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -106,7 +109,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, escaped quotes scalar value' => [
                 'assertionString' => '".selector" is "\"value\""',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -119,7 +122,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, lacking value' => [
                 'assertionString' => '".selector" is',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -129,7 +132,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is-not, scalar value' => [
                 'assertionString' => '".selector" is-not "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -142,7 +145,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is-not, lacking value' => [
                 'assertionString' => '".selector" is-not',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -152,7 +155,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, exists, no value' => [
                 'assertionString' => '".selector" exists',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -162,7 +165,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, exists, scalar value is ignored' => [
                 'assertionString' => '".selector" exists "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -172,7 +175,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, exists, data parameter value is ignored' => [
                 'assertionString' => '".selector" exists $data.name"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -182,7 +185,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, includes, scalar value' => [
                 'assertionString' => '".selector" includes "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -195,7 +198,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, includes, lacking value' => [
                 'assertionString' => '".selector" includes',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -205,7 +208,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, excludes, scalar value' => [
                 'assertionString' => '".selector" excludes "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -218,7 +221,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, excludes, lacking value' => [
                 'assertionString' => '".selector" excludes',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -228,7 +231,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, matches, scalar value' => [
                 'assertionString' => '".selector" matches "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -241,7 +244,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, matches, lacking value' => [
                 'assertionString' => '".selector" matches',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -251,7 +254,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'comparison-including css selector, is, scalar value' => [
                 'assertionString' => '".selector is is-not exists not-exists includes excludes matches foo" is "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector is is-not exists not-exists includes excludes matches foo'
@@ -264,7 +267,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple xpath expression, is, scalar value' => [
                 'assertionString' => '"//foo" is "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::XPATH_EXPRESSION,
                     '//foo'
@@ -278,7 +281,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             'comparison-including non-simple xpath expression, is, scalar value' => [
                 'assertionString' =>
                     '"//a[ends-with(@href is exists not-exists matches includes excludes, \".pdf\")]" is "value"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::XPATH_EXPRESSION,
                     '//a[ends-with(@href is exists not-exists matches includes excludes, \".pdf\")]'
@@ -291,7 +294,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'page model element reference' => [
                 'assertionString' => 'page_import_name.elements.element_name is "value"',
-                'pages' => [
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(
                         new Uri('http://example.com'),
                         [
@@ -301,7 +304,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
                             )
                         ]
                     )
-                ],
+                ]),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -319,7 +322,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $assertionString = '';
 
-        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, []);
+        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, new EmptyPageCollection());
 
         $this->assertInstanceOf(AssertionInterface::class, $assertion);
         $this->assertSame($assertionString, $assertion->getAssertionString());

--- a/tests/Unit/Factory/AssertionFactoryTest.php
+++ b/tests/Unit/Factory/AssertionFactoryTest.php
@@ -38,12 +38,12 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateFromAssertionString(
         string $assertionString,
-        PageCollectionInterface $pageCollection,
+        PageCollectionInterface $pages,
         IdentifierInterface $expectedIdentifier,
         string $expectedComparison,
         ?ValueInterface $expectedValue
     ) {
-        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, $pageCollection);
+        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, $pages);
 
         $this->assertInstanceOf(AssertionInterface::class, $assertion);
         $this->assertSame($assertionString, $assertion->getAssertionString());
@@ -57,7 +57,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'simple css selector, is, scalar value' => [
                 'assertionString' => '".selector" is "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -70,7 +70,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector with element reference, is, scalar value' => [
                 'assertionString' => '"{{ reference }} .selector" is "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '{{ reference }} .selector'
@@ -83,7 +83,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, data parameter value' => [
                 'assertionString' => '".selector" is $data.name',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -96,7 +96,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, element parameter value' => [
                 'actionString' => '".selector" is $elements.name',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -109,7 +109,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, escaped quotes scalar value' => [
                 'assertionString' => '".selector" is "\"value\""',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -122,7 +122,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, lacking value' => [
                 'assertionString' => '".selector" is',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -132,7 +132,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is-not, scalar value' => [
                 'assertionString' => '".selector" is-not "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -145,7 +145,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is-not, lacking value' => [
                 'assertionString' => '".selector" is-not',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -155,7 +155,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, exists, no value' => [
                 'assertionString' => '".selector" exists',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -165,7 +165,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, exists, scalar value is ignored' => [
                 'assertionString' => '".selector" exists "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -175,7 +175,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, exists, data parameter value is ignored' => [
                 'assertionString' => '".selector" exists $data.name"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -185,7 +185,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, includes, scalar value' => [
                 'assertionString' => '".selector" includes "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -198,7 +198,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, includes, lacking value' => [
                 'assertionString' => '".selector" includes',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -208,7 +208,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, excludes, scalar value' => [
                 'assertionString' => '".selector" excludes "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -221,7 +221,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, excludes, lacking value' => [
                 'assertionString' => '".selector" excludes',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -231,7 +231,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, matches, scalar value' => [
                 'assertionString' => '".selector" matches "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -244,7 +244,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, matches, lacking value' => [
                 'assertionString' => '".selector" matches',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -254,7 +254,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'comparison-including css selector, is, scalar value' => [
                 'assertionString' => '".selector is is-not exists not-exists includes excludes matches foo" is "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector is is-not exists not-exists includes excludes matches foo'
@@ -267,7 +267,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple xpath expression, is, scalar value' => [
                 'assertionString' => '"//foo" is "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::XPATH_EXPRESSION,
                     '//foo'
@@ -281,7 +281,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             'comparison-including non-simple xpath expression, is, scalar value' => [
                 'assertionString' =>
                     '"//a[ends-with(@href is exists not-exists matches includes excludes, \".pdf\")]" is "value"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::XPATH_EXPRESSION,
                     '//a[ends-with(@href is exists not-exists matches includes excludes, \".pdf\")]'

--- a/tests/Unit/Factory/AssertionFactoryTest.php
+++ b/tests/Unit/Factory/AssertionFactoryTest.php
@@ -1,12 +1,14 @@
 <?php
+/** @noinspection PhpUnhandledExceptionInspection */
 /** @noinspection PhpDocSignatureInspection */
 
 namespace webignition\BasilParser\Tests\Unit\Factory;
 
+use Nyholm\Psr7\Uri;
 use webignition\BasilParser\Factory\AssertionFactory;
-use webignition\BasilParser\Model\Assertion\Assertion;
 use webignition\BasilParser\Model\Assertion\AssertionComparisons;
 use webignition\BasilParser\Model\Assertion\AssertionInterface;
+use webignition\BasilParser\Model\Page\Page;
 use webignition\BasilParser\Model\Value\Value;
 use webignition\BasilParser\Model\Value\ValueInterface;
 use webignition\BasilParser\Model\Value\ValueTypes;
@@ -33,11 +35,12 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateFromAssertionString(
         string $assertionString,
+        array $pages,
         IdentifierInterface $expectedIdentifier,
         string $expectedComparison,
         ?ValueInterface $expectedValue
     ) {
-        $assertion = $this->assertionFactory->createFromAssertionString($assertionString);
+        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, $pages);
 
         $this->assertInstanceOf(AssertionInterface::class, $assertion);
         $this->assertSame($assertionString, $assertion->getAssertionString());
@@ -51,6 +54,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'simple css selector, is, scalar value' => [
                 'assertionString' => '".selector" is "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -63,6 +67,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector with element reference, is, scalar value' => [
                 'assertionString' => '"{{ reference }} .selector" is "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '{{ reference }} .selector'
@@ -75,6 +80,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, data parameter value' => [
                 'assertionString' => '".selector" is $data.name',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -87,6 +93,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, element parameter value' => [
                 'actionString' => '".selector" is $elements.name',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -99,6 +106,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, escaped quotes scalar value' => [
                 'assertionString' => '".selector" is "\"value\""',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -111,6 +119,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is, lacking value' => [
                 'assertionString' => '".selector" is',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -120,6 +129,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is-not, scalar value' => [
                 'assertionString' => '".selector" is-not "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -132,6 +142,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, is-not, lacking value' => [
                 'assertionString' => '".selector" is-not',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -141,6 +152,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, exists, no value' => [
                 'assertionString' => '".selector" exists',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -150,6 +162,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, exists, scalar value is ignored' => [
                 'assertionString' => '".selector" exists "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -159,6 +172,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, exists, data parameter value is ignored' => [
                 'assertionString' => '".selector" exists $data.name"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -168,6 +182,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, includes, scalar value' => [
                 'assertionString' => '".selector" includes "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -180,6 +195,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, includes, lacking value' => [
                 'assertionString' => '".selector" includes',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -189,6 +205,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, excludes, scalar value' => [
                 'assertionString' => '".selector" excludes "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -201,6 +218,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, excludes, lacking value' => [
                 'assertionString' => '".selector" excludes',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -210,6 +228,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, matches, scalar value' => [
                 'assertionString' => '".selector" matches "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -222,6 +241,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple css selector, matches, lacking value' => [
                 'assertionString' => '".selector" matches',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector'
@@ -231,6 +251,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'comparison-including css selector, is, scalar value' => [
                 'assertionString' => '".selector is is-not exists not-exists includes excludes matches foo" is "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::CSS_SELECTOR,
                     '.selector is is-not exists not-exists includes excludes matches foo'
@@ -243,6 +264,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             ],
             'simple xpath expression, is, scalar value' => [
                 'assertionString' => '"//foo" is "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::XPATH_EXPRESSION,
                     '//foo'
@@ -256,9 +278,33 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
             'comparison-including non-simple xpath expression, is, scalar value' => [
                 'assertionString' =>
                     '"//a[ends-with(@href is exists not-exists matches includes excludes, \".pdf\")]" is "value"',
+                'pages' => [],
                 'expectedIdentifier' => new Identifier(
                     IdentifierTypes::XPATH_EXPRESSION,
                     '//a[ends-with(@href is exists not-exists matches includes excludes, \".pdf\")]'
+                ),
+                'expectedComparison' => AssertionComparisons::IS,
+                'expectedValue' => new Value(
+                    ValueTypes::STRING,
+                    'value'
+                ),
+            ],
+            'page model element reference' => [
+                'assertionString' => 'page_import_name.elements.element_name is "value"',
+                'pages' => [
+                    'page_import_name' => new Page(
+                        new Uri('http://example.com'),
+                        [
+                            'element_name' => new Identifier(
+                                IdentifierTypes::CSS_SELECTOR,
+                                '.selector'
+                            )
+                        ]
+                    )
+                ],
+                'expectedIdentifier' => new Identifier(
+                    IdentifierTypes::CSS_SELECTOR,
+                    '.selector'
                 ),
                 'expectedComparison' => AssertionComparisons::IS,
                 'expectedValue' => new Value(
@@ -273,7 +319,7 @@ class AssertionFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $assertionString = '';
 
-        $assertion = $this->assertionFactory->createFromAssertionString($assertionString);
+        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, []);
 
         $this->assertInstanceOf(AssertionInterface::class, $assertion);
         $this->assertSame($assertionString, $assertion->getAssertionString());

--- a/tests/Unit/Factory/IdentifierFactoryTest.php
+++ b/tests/Unit/Factory/IdentifierFactoryTest.php
@@ -41,12 +41,12 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateSuccess(
         string $identifierString,
-        PageCollectionInterface $pageCollection,
+        PageCollectionInterface $pages,
         string $expectedType,
         string $expectedValue,
         int $expectedPosition
     ) {
-        $identifier = $this->factory->create($identifierString, $pageCollection);
+        $identifier = $this->factory->create($identifierString, $pages);
 
         $this->assertInstanceOf(IdentifierInterface::class, $identifier);
 
@@ -64,56 +64,56 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'css id selector' => [
                 'identifierString' => '"#element-id"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '#element-id',
                 'expectedPosition' => 1,
             ],
             'css class selector, position: null' => [
                 'identifierString' => '".listed-item"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => 1,
             ],
             'css class selector; position: 1' => [
                 'identifierString' => '".listed-item":1',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => 1,
             ],
             'css class selector; position: 3' => [
                 'identifierString' => '".listed-item":3',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => 3,
             ],
             'css class selector; position: -1' => [
                 'identifierString' => '".listed-item":-1',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => -1,
             ],
             'css class selector; position: -3' => [
                 'identifierString' => '".listed-item":-3',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => -3,
             ],
             'css class selector; position: first' => [
                 'identifierString' => '".listed-item":first',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => 1,
             ],
             'css class selector; position: last' => [
                 'identifierString' => '".listed-item":last',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => -1,
@@ -126,56 +126,56 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'xpath id selector' => [
                 'identifierString' => '"//*[@id="element-id"]"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//*[@id="element-id"]',
                 'expectedPosition' => 1,
             ],
             'xpath attribute selector, position: null' => [
                 'identifierString' => '"//input[@type="submit"]"',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => 1,
             ],
             'xpath attribute selector; position: 1' => [
                 'identifierString' => '"//input[@type="submit"]":1',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => 1,
             ],
             'xpath attribute selector; position: 3' => [
                 'identifierString' => '"//input[@type="submit"]":3',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => 3,
             ],
             'xpath attribute selector; position: -1' => [
                 'identifierString' => '"//input[@type="submit"]":-1',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => -1,
             ],
             'xpath attribute selector; position: -3' => [
                 'identifierString' => '"//input[@type="submit"]":-3',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => -3,
             ],
             'xpath attribute selector; position: first' => [
                 'identifierString' => '"//input[@type="submit"]":first',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => 1,
             ],
             'xpath attribute selector; position: last' => [
                 'identifierString' => '"//input[@type="submit"]":last',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => -1,
@@ -188,7 +188,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'element parameter' => [
                 'identifierString' => '$elements.name',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::ELEMENT_PARAMETER,
                 'expectedValue' => '$elements.name',
                 'expectedPosition' => 1,
@@ -201,7 +201,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'element parameter' => [
                 'identifierString' => 'page_import_name.elements.element_name',
-                'pageCollection' => new PopulatedPageCollection([
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(
                         new Uri('https://example.com'),
                         [
@@ -224,7 +224,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'page object parameter' => [
                 'identifierString' => '$page.title',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::PAGE_OBJECT_PARAMETER,
                 'expectedValue' => '$page.title',
                 'expectedPosition' => 1,
@@ -237,7 +237,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'browser object parameter' => [
                 'identifierString' => '$browser.url',
-                'pageCollection' => new EmptyPageCollection(),
+                'pages' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::BROWSER_OBJECT_PARAMETER,
                 'expectedValue' => '$browser.url',
                 'expectedPosition' => 1,

--- a/tests/Unit/Factory/IdentifierFactoryTest.php
+++ b/tests/Unit/Factory/IdentifierFactoryTest.php
@@ -5,7 +5,7 @@
 namespace webignition\BasilParser\Tests\Unit\Factory;
 
 use Nyholm\Psr7\Uri;
-use webignition\BasilParser\Exception\InvalidPageElementReferenceException;
+use webignition\BasilParser\Exception\MalformedPageElementReferenceException;
 use webignition\BasilParser\Exception\UnknownPageElementException;
 use webignition\BasilParser\Exception\UnknownPageException;
 use webignition\BasilParser\Factory\IdentifierFactory;
@@ -361,8 +361,8 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateForInvalidPageElementReference()
     {
-        $this->expectException(InvalidPageElementReferenceException::class);
-        $this->expectExceptionMessage('Invalid page element reference "invalid-page-model-element-reference"');
+        $this->expectException(MalformedPageElementReferenceException::class);
+        $this->expectExceptionMessage('Malformed page element reference "invalid-page-model-element-reference"');
 
         $this->factory->create('invalid-page-model-element-reference', []);
     }

--- a/tests/Unit/Factory/IdentifierFactoryTest.php
+++ b/tests/Unit/Factory/IdentifierFactoryTest.php
@@ -349,8 +349,8 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateEmpty()
     {
-        $this->assertNull($this->factory->create(''));
-        $this->assertNull($this->factory->create(' '));
+        $this->assertNull($this->factory->create('', []));
+        $this->assertNull($this->factory->create(' ', []));
     }
 
     public function testCreateWithElementReferenceEmpty()
@@ -364,7 +364,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidPageElementReferenceException::class);
         $this->expectExceptionMessage('Invalid page element reference "invalid-page-model-element-reference"');
 
-        $this->factory->create('invalid-page-model-element-reference');
+        $this->factory->create('invalid-page-model-element-reference', []);
     }
 
     public function testCreateForPageElementReferenceForUnknownPage()
@@ -372,7 +372,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         $this->expectException(UnknownPageException::class);
         $this->expectExceptionMessage('Unknown page "import_name"');
 
-        $this->factory->create('import_name.elements.element_name');
+        $this->factory->create('import_name.elements.element_name', []);
     }
 
     public function testCreateForPageElementReferenceForUnknownElement()

--- a/tests/Unit/Factory/IdentifierFactoryTest.php
+++ b/tests/Unit/Factory/IdentifierFactoryTest.php
@@ -13,6 +13,9 @@ use webignition\BasilParser\Model\Identifier\Identifier;
 use webignition\BasilParser\Model\Identifier\IdentifierInterface;
 use webignition\BasilParser\Model\Identifier\IdentifierTypes;
 use webignition\BasilParser\Model\Page\Page;
+use webignition\BasilParser\PageCollection\EmptyPageCollection;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
+use webignition\BasilParser\PageCollection\PopulatedPageCollection;
 
 class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
 {
@@ -38,12 +41,12 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateSuccess(
         string $identifierString,
-        array $pages,
+        PageCollectionInterface $pageCollection,
         string $expectedType,
         string $expectedValue,
         int $expectedPosition
     ) {
-        $identifier = $this->factory->create($identifierString, $pages);
+        $identifier = $this->factory->create($identifierString, $pageCollection);
 
         $this->assertInstanceOf(IdentifierInterface::class, $identifier);
 
@@ -61,56 +64,56 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'css id selector' => [
                 'identifierString' => '"#element-id"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '#element-id',
                 'expectedPosition' => 1,
             ],
             'css class selector, position: null' => [
                 'identifierString' => '".listed-item"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => 1,
             ],
             'css class selector; position: 1' => [
                 'identifierString' => '".listed-item":1',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => 1,
             ],
             'css class selector; position: 3' => [
                 'identifierString' => '".listed-item":3',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => 3,
             ],
             'css class selector; position: -1' => [
                 'identifierString' => '".listed-item":-1',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => -1,
             ],
             'css class selector; position: -3' => [
                 'identifierString' => '".listed-item":-3',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => -3,
             ],
             'css class selector; position: first' => [
                 'identifierString' => '".listed-item":first',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => 1,
             ],
             'css class selector; position: last' => [
                 'identifierString' => '".listed-item":last',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.listed-item',
                 'expectedPosition' => -1,
@@ -123,56 +126,56 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'xpath id selector' => [
                 'identifierString' => '"//*[@id="element-id"]"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//*[@id="element-id"]',
                 'expectedPosition' => 1,
             ],
             'xpath attribute selector, position: null' => [
                 'identifierString' => '"//input[@type="submit"]"',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => 1,
             ],
             'xpath attribute selector; position: 1' => [
                 'identifierString' => '"//input[@type="submit"]":1',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => 1,
             ],
             'xpath attribute selector; position: 3' => [
                 'identifierString' => '"//input[@type="submit"]":3',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => 3,
             ],
             'xpath attribute selector; position: -1' => [
                 'identifierString' => '"//input[@type="submit"]":-1',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => -1,
             ],
             'xpath attribute selector; position: -3' => [
                 'identifierString' => '"//input[@type="submit"]":-3',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => -3,
             ],
             'xpath attribute selector; position: first' => [
                 'identifierString' => '"//input[@type="submit"]":first',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => 1,
             ],
             'xpath attribute selector; position: last' => [
                 'identifierString' => '"//input[@type="submit"]":last',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::XPATH_EXPRESSION,
                 'expectedValue' => '//input[@type="submit"]',
                 'expectedPosition' => -1,
@@ -184,10 +187,10 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
     {
         return [
             'element parameter' => [
-                'identifierString' => '$element.name',
-                'pages' => [],
+                'identifierString' => '$elements.name',
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::ELEMENT_PARAMETER,
-                'expectedValue' => '$element.name',
+                'expectedValue' => '$elements.name',
                 'expectedPosition' => 1,
             ],
         ];
@@ -198,7 +201,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'element parameter' => [
                 'identifierString' => 'page_import_name.elements.element_name',
-                'pages' => [
+                'pageCollection' => new PopulatedPageCollection([
                     'page_import_name' => new Page(
                         new Uri('https://example.com'),
                         [
@@ -208,7 +211,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
                             )
                         ]
                     )
-                ],
+                ]),
                 'expectedType' => IdentifierTypes::CSS_SELECTOR,
                 'expectedValue' => '.selector',
                 'expectedPosition' => 1,
@@ -221,7 +224,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'page object parameter' => [
                 'identifierString' => '$page.title',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::PAGE_OBJECT_PARAMETER,
                 'expectedValue' => '$page.title',
                 'expectedPosition' => 1,
@@ -234,7 +237,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'browser object parameter' => [
                 'identifierString' => '$browser.url',
-                'pages' => [],
+                'pageCollection' => new EmptyPageCollection(),
                 'expectedType' => IdentifierTypes::BROWSER_OBJECT_PARAMETER,
                 'expectedValue' => '$browser.url',
                 'expectedPosition' => 1,
@@ -349,8 +352,8 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateEmpty()
     {
-        $this->assertNull($this->factory->create('', []));
-        $this->assertNull($this->factory->create(' ', []));
+        $this->assertNull($this->factory->create('', new EmptyPageCollection()));
+        $this->assertNull($this->factory->create(' ', new EmptyPageCollection()));
     }
 
     public function testCreateWithElementReferenceEmpty()
@@ -359,12 +362,12 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->factory->createWithElementReference(' ', null, []));
     }
 
-    public function testCreateForInvalidPageElementReference()
+    public function testCreateForMalformedPageElementReference()
     {
         $this->expectException(MalformedPageElementReferenceException::class);
         $this->expectExceptionMessage('Malformed page element reference "invalid-page-model-element-reference"');
 
-        $this->factory->create('invalid-page-model-element-reference', []);
+        $this->factory->create('invalid-page-model-element-reference', new EmptyPageCollection());
     }
 
     public function testCreateForPageElementReferenceForUnknownPage()
@@ -372,7 +375,7 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
         $this->expectException(UnknownPageException::class);
         $this->expectExceptionMessage('Unknown page "import_name"');
 
-        $this->factory->create('import_name.elements.element_name', []);
+        $this->factory->create('import_name.elements.element_name', new EmptyPageCollection());
     }
 
     public function testCreateForPageElementReferenceForUnknownElement()
@@ -382,9 +385,9 @@ class IdentifierFactoryTest extends \PHPUnit\Framework\TestCase
 
         $this->factory->create(
             'import_name.elements.element_name',
-            [
+            new PopulatedPageCollection([
                 'import_name' => new Page(new Uri('http://example.com'), [])
-            ]
+            ])
         );
     }
 }

--- a/tests/Unit/Factory/StepFactoryTest.php
+++ b/tests/Unit/Factory/StepFactoryTest.php
@@ -1,8 +1,10 @@
 <?php
+/** @noinspection PhpUnhandledExceptionInspection */
 /** @noinspection PhpDocSignatureInspection */
 
 namespace webignition\BasilParser\Tests\Unit\Factory;
 
+use Nyholm\Psr7\Uri;
 use webignition\BasilParser\Factory\StepFactory;
 use webignition\BasilParser\Model\Action\ActionTypes;
 use webignition\BasilParser\Model\Action\InputAction;
@@ -11,6 +13,7 @@ use webignition\BasilParser\Model\Assertion\Assertion;
 use webignition\BasilParser\Model\Assertion\AssertionComparisons;
 use webignition\BasilParser\Model\Identifier\Identifier;
 use webignition\BasilParser\Model\Identifier\IdentifierTypes;
+use webignition\BasilParser\Model\Page\Page;
 use webignition\BasilParser\Model\Step\Step;
 use webignition\BasilParser\Model\Step\StepInterface;
 use webignition\BasilParser\Model\Value\Value;
@@ -33,9 +36,9 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider createFromStepDataDataProvider
      */
-    public function testCreateFromStepData(array $stepData, StepInterface $expectedStep)
+    public function testCreateFromStepData(array $stepData, array $pages, StepInterface $expectedStep)
     {
-        $step = $this->stepFactory->createFromStepData($stepData);
+        $step = $this->stepFactory->createFromStepData($stepData, $pages);
 
         $this->assertEquals($expectedStep, $step);
     }
@@ -45,6 +48,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'empty step data' => [
                 'stepData' => [],
+                'pages' => [],
                 'expectedStep' => new Step([], []),
             ],
             'empty actions and empty assertions' => [
@@ -58,6 +62,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                         ' ',
                     ],
                 ],
+                'pages' => [],
                 'expectedStep' => new Step([], []),
             ],
             'actions only' => [
@@ -67,6 +72,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                         'set ".input" to "value"',
                     ],
                 ],
+                'pages' => [],
                 'expectedStep' => new Step(
                     [
                         new InteractionAction(
@@ -99,6 +105,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                         '".input" exists'
                     ],
                 ],
+                'pages' => [],
                 'expectedStep' => new Step(
                     [
                     ],
@@ -120,6 +127,38 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                             new Identifier(
                                 IdentifierTypes::CSS_SELECTOR,
                                 '.input'
+                            ),
+                            AssertionComparisons::EXISTS
+                        ),
+                    ]
+                ),
+            ],
+            'page model element reference' => [
+                'stepData' => [
+                    StepFactory::KEY_ASSERTIONS => [
+                        'page_import_name.elements.element_name exists'
+                    ],
+                ],
+                'pages' => [
+                    'page_import_name' => new Page(
+                        new Uri('http://example.com'),
+                        [
+                            'element_name' => new Identifier(
+                                IdentifierTypes::CSS_SELECTOR,
+                                '.selector'
+                            ),
+                        ]
+                    )
+                ],
+                'expectedStep' => new Step(
+                    [
+                    ],
+                    [
+                        new Assertion(
+                            'page_import_name.elements.element_name exists',
+                            new Identifier(
+                                IdentifierTypes::CSS_SELECTOR,
+                                '.selector'
                             ),
                             AssertionComparisons::EXISTS
                         ),

--- a/tests/Unit/Factory/StepFactoryTest.php
+++ b/tests/Unit/Factory/StepFactoryTest.php
@@ -133,8 +133,11 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                     ]
                 ),
             ],
-            'page model element reference' => [
+            'page model element references' => [
                 'stepData' => [
+                    StepFactory::KEY_ACTIONS => [
+                        'click page_import_name.elements.element_name'
+                    ],
                     StepFactory::KEY_ASSERTIONS => [
                         'page_import_name.elements.element_name exists'
                     ],
@@ -152,6 +155,14 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                 ],
                 'expectedStep' => new Step(
                     [
+                        new InteractionAction(
+                            ActionTypes::CLICK,
+                            new Identifier(
+                                IdentifierTypes::CSS_SELECTOR,
+                                '.selector'
+                            ),
+                            'page_import_name.elements.element_name'
+                        )
                     ],
                     [
                         new Assertion(

--- a/tests/Unit/Factory/StepFactoryTest.php
+++ b/tests/Unit/Factory/StepFactoryTest.php
@@ -18,6 +18,9 @@ use webignition\BasilParser\Model\Step\Step;
 use webignition\BasilParser\Model\Step\StepInterface;
 use webignition\BasilParser\Model\Value\Value;
 use webignition\BasilParser\Model\Value\ValueTypes;
+use webignition\BasilParser\PageCollection\EmptyPageCollection;
+use webignition\BasilParser\PageCollection\PageCollectionInterface;
+use webignition\BasilParser\PageCollection\PopulatedPageCollection;
 
 class StepFactoryTest extends \PHPUnit\Framework\TestCase
 {
@@ -36,7 +39,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider createFromStepDataDataProvider
      */
-    public function testCreateFromStepData(array $stepData, array $pages, StepInterface $expectedStep)
+    public function testCreateFromStepData(array $stepData, PageCollectionInterface $pages, StepInterface $expectedStep)
     {
         $step = $this->stepFactory->createFromStepData($stepData, $pages);
 
@@ -48,7 +51,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             'empty step data' => [
                 'stepData' => [],
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedStep' => new Step([], []),
             ],
             'empty actions and empty assertions' => [
@@ -62,7 +65,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                         ' ',
                     ],
                 ],
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedStep' => new Step([], []),
             ],
             'actions only' => [
@@ -72,7 +75,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                         'set ".input" to "value"',
                     ],
                 ],
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedStep' => new Step(
                     [
                         new InteractionAction(
@@ -105,7 +108,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                         '".input" exists'
                     ],
                 ],
-                'pages' => [],
+                'pages' => new EmptyPageCollection(),
                 'expectedStep' => new Step(
                     [
                     ],
@@ -142,7 +145,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                         'page_import_name.elements.element_name exists'
                     ],
                 ],
-                'pages' => [
+                'pages' => new PopulatedPageCollection([
                     'page_import_name' => new Page(
                         new Uri('http://example.com'),
                         [
@@ -152,7 +155,7 @@ class StepFactoryTest extends \PHPUnit\Framework\TestCase
                             ),
                         ]
                     )
-                ],
+                ]),
                 'expectedStep' => new Step(
                     [
                         new InteractionAction(

--- a/tests/Unit/Factory/Test/TestFactoryTest.php
+++ b/tests/Unit/Factory/Test/TestFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+/** @noinspection PhpUnhandledExceptionInspection */
 /** @noinspection PhpDocSignatureInspection */
 
 namespace webignition\BasilParser\Tests\Unit\Factory\Test;
@@ -47,9 +48,9 @@ class TestFactoryTest extends \PHPUnit\Framework\TestCase
         $pageFactory = new PageFactory();
         $pageLoader = new PageLoader($yamlLoader, $pageFactory);
 
-        $stepBuilder = new StepBuilder($stepFactory, $pageLoader, $stepLoader, $yamlLoader);
+        $stepBuilder = new StepBuilder($stepFactory, $stepLoader, $yamlLoader);
 
-        $this->testFactory = new TestFactory($configurationFactory, $stepBuilder);
+        $this->testFactory = new TestFactory($configurationFactory, $pageLoader, $stepBuilder);
     }
 
     /**

--- a/tests/Unit/Factory/Test/TestFactoryTest.php
+++ b/tests/Unit/Factory/Test/TestFactoryTest.php
@@ -101,7 +101,7 @@ class TestFactoryTest extends \PHPUnit\Framework\TestCase
                     'invalid' => new Step([], []),
                 ]),
             ],
-            'inline steps only' => [
+            'inline step, scalar values' => [
                 'testData' => [
                     TestFactory::KEY_CONFIGURATION => $configurationData,
                     'verify page is open' => [
@@ -155,6 +155,56 @@ class TestFactoryTest extends \PHPUnit\Framework\TestCase
                                 new Value(
                                     ValueTypes::STRING,
                                     'example - Example Domain'
+                                )
+                            ),
+                        ]
+                    ),
+                ]),
+            ],
+            'inline step, page element references' => [
+                'testData' => [
+                    TestFactory::KEY_CONFIGURATION => $configurationData,
+                    TestFactory::KEY_IMPORTS => [
+                        TestFactory::KEY_IMPORTS_PAGES => [
+                            'page_import_name' => FixturePathFinder::find('Page/example.com.button.heading.yml'),
+                        ],
+                    ],
+                    'query "example"' => [
+                        StepFactory::KEY_ACTIONS => [
+                            'click page_import_name.elements.button',
+                        ],
+                        StepFactory::KEY_ASSERTIONS => [
+                            'page_import_name.elements.heading is "example"',
+                        ],
+                    ],
+                ],
+                'expectedTest' => new Test($expectedConfiguration, [
+                    'query "example"' => new Step(
+                        [
+                            new InteractionAction(
+                                ActionTypes::CLICK,
+                                new Identifier(
+                                    IdentifierTypes::CSS_SELECTOR,
+                                    '.button',
+                                    null,
+                                    'button'
+                                ),
+                                'page_import_name.elements.button'
+                            ),
+                        ],
+                        [
+                            new Assertion(
+                                'page_import_name.elements.heading is "example"',
+                                new Identifier(
+                                    IdentifierTypes::CSS_SELECTOR,
+                                    '.heading',
+                                    null,
+                                    'heading'
+                                ),
+                                AssertionComparisons::IS,
+                                new Value(
+                                    ValueTypes::STRING,
+                                    'example'
                                 )
                             ),
                         ]

--- a/tests/Unit/Factory/Test/TestFactoryTest.php
+++ b/tests/Unit/Factory/Test/TestFactoryTest.php
@@ -17,6 +17,7 @@ use webignition\BasilParser\Model\Action\ActionTypes;
 use webignition\BasilParser\Model\Action\InteractionAction;
 use webignition\BasilParser\Model\Assertion\Assertion;
 use webignition\BasilParser\Model\Assertion\AssertionComparisons;
+use webignition\BasilParser\Model\DataSet\DataSet;
 use webignition\BasilParser\Model\Identifier\Identifier;
 use webignition\BasilParser\Model\Identifier\IdentifierTypes;
 use webignition\BasilParser\Model\Step\Step;
@@ -285,6 +286,59 @@ class TestFactoryTest extends \PHPUnit\Framework\TestCase
                                 ),
                             ]
                         ),
+                    ]
+                ),
+            ],
+            'step import, inline data' => [
+                'testData' => [
+                    TestFactory::KEY_CONFIGURATION => $configurationData,
+                    TestFactory::KEY_IMPORTS => [
+                        TestFactory::KEY_IMPORTS_STEPS => [
+                            'step_import_name' => FixturePathFinder::find('Step/data-parameters.yml'),
+                        ],
+                    ],
+                    'step_name' => [
+                        'use' => 'step_import_name',
+                        'data' => [
+                            'data_set_1' => new DataSet([
+                                'expected_title' => 'Foo',
+                            ]),
+                        ]
+                    ],
+                ],
+                'expectedTest' => new Test(
+                    $expectedConfiguration,
+                    [
+                        'step_name' => (new Step(
+                            [
+                                new InteractionAction(
+                                    ActionTypes::CLICK,
+                                    new Identifier(
+                                        IdentifierTypes::CSS_SELECTOR,
+                                        '.button'
+                                    ),
+                                    '".button"'
+                                )
+                            ],
+                            [
+                                new Assertion(
+                                    '".heading" includes $data.expected_title',
+                                    new Identifier(
+                                        IdentifierTypes::CSS_SELECTOR,
+                                        '.heading'
+                                    ),
+                                    AssertionComparisons::INCLUDES,
+                                    new Value(
+                                        ValueTypes::DATA_PARAMETER,
+                                        '$data.expected_title'
+                                    )
+                                ),
+                            ]
+                        ))->withDataSets([
+                            'data_set_1' => new DataSet([
+                                'expected_title' => 'Foo',
+                            ]),
+                        ]),
                     ]
                 ),
             ],

--- a/tests/Unit/Factory/Test/TestFactoryTest.php
+++ b/tests/Unit/Factory/Test/TestFactoryTest.php
@@ -401,6 +401,64 @@ class TestFactoryTest extends \PHPUnit\Framework\TestCase
                     ]
                 ),
             ],
+            'step import, uses page imported page elements' => [
+                'testData' => [
+                    TestFactory::KEY_CONFIGURATION => $configurationData,
+                    TestFactory::KEY_IMPORTS => [
+                        TestFactory::KEY_IMPORTS_STEPS => [
+                            'step_import_name' => FixturePathFinder::find('Step/element-parameters.yml'),
+                        ],
+                        TestFactory::KEY_IMPORTS_PAGES => [
+                            'page_import_name' =>
+                                FixturePathFinder::find('Page/example.com.heading.yml')
+                        ],
+                    ],
+                    'step_name' => [
+                        'use' => 'step_import_name',
+                        'elements' => [
+                            'heading' => 'page_import_name.elements.heading'
+                        ],
+                    ],
+                ],
+                'expectedTest' => new Test(
+                    $expectedConfiguration,
+                    [
+                        'step_name' => (new Step(
+                            [
+                                new InteractionAction(
+                                    ActionTypes::CLICK,
+                                    new Identifier(
+                                        IdentifierTypes::CSS_SELECTOR,
+                                        '.button'
+                                    ),
+                                    '".button"'
+                                )
+                            ],
+                            [
+                                new Assertion(
+                                    '$elements.heading includes "Hello World"',
+                                    new Identifier(
+                                        IdentifierTypes::ELEMENT_PARAMETER,
+                                        '$elements.heading'
+                                    ),
+                                    AssertionComparisons::INCLUDES,
+                                    new Value(
+                                        ValueTypes::STRING,
+                                        'Hello World'
+                                    )
+                                ),
+                            ]
+                        ))->withElementIdentifiers([
+                            'heading' => new Identifier(
+                                IdentifierTypes::CSS_SELECTOR,
+                                '.heading',
+                                null,
+                                'heading'
+                            ),
+                        ]),
+                    ]
+                ),
+            ],
         ];
     }
 }

--- a/tests/Unit/PageCollection/DeferredPageCollectionTest.php
+++ b/tests/Unit/PageCollection/DeferredPageCollectionTest.php
@@ -11,14 +11,14 @@ use webignition\BasilParser\Factory\PageFactory;
 use webignition\BasilParser\Loader\PageLoader;
 use webignition\BasilParser\Loader\YamlLoader;
 use webignition\BasilParser\Model\Page\PageInterface;
-use webignition\BasilParser\PageCollection\PageCollection;
+use webignition\BasilParser\PageCollection\DeferredPageCollection;
 use webignition\BasilParser\Tests\Services\FixturePathFinder;
 
-class PageCollectionTest extends \PHPUnit\Framework\TestCase
+class DeferredPageCollectionTest extends \PHPUnit\Framework\TestCase
 {
     public function testFindPageSuccess()
     {
-        $pageCollection = new PageCollection($this->createPageLoader(), [
+        $pageCollection = new DeferredPageCollection($this->createPageLoader(), [
             'page_import_name' => FixturePathFinder::find('Page/example.com.heading.yml'),
         ]);
 
@@ -32,7 +32,7 @@ class PageCollectionTest extends \PHPUnit\Framework\TestCase
         $this->expectException(UnknownPageException::class);
         $this->expectExceptionMessage('Unknown page "page_import_name"');
 
-        $pageCollection = new PageCollection($this->createPageLoader(), []);
+        $pageCollection = new DeferredPageCollection($this->createPageLoader(), []);
 
         $pageCollection->findPage('page_import_name');
     }
@@ -42,7 +42,7 @@ class PageCollectionTest extends \PHPUnit\Framework\TestCase
         $this->expectException(NonRetrievablePageException::class);
         $this->expectExceptionMessage('Cannot retrieve page "page_import_name" from "non-existent-file.yml"');
 
-        $pageCollection = new PageCollection($this->createPageLoader(), [
+        $pageCollection = new DeferredPageCollection($this->createPageLoader(), [
             'page_import_name' => 'non-existent-file.yml',
         ]);
 

--- a/tests/Unit/PageCollection/EmptyPageCollectionTest.php
+++ b/tests/Unit/PageCollection/EmptyPageCollectionTest.php
@@ -1,0 +1,21 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+/** @noinspection PhpDocSignatureInspection */
+
+namespace webignition\BasilParser\Tests\Unit\PageCollection;
+
+use webignition\BasilParser\Exception\UnknownPageException;
+use webignition\BasilParser\PageCollection\EmptyPageCollection;
+
+class EmptyPageCollectionTest extends \PHPUnit\Framework\TestCase
+{
+    public function testFindPageThrowsUnknownPageException()
+    {
+        $this->expectException(UnknownPageException::class);
+        $this->expectExceptionMessage('Unknown page "page_import_name"');
+
+        $pageCollection = new EmptyPageCollection();
+
+        $pageCollection->findPage('page_import_name');
+    }
+}

--- a/tests/Unit/PageCollection/PageCollectionTest.php
+++ b/tests/Unit/PageCollection/PageCollectionTest.php
@@ -1,0 +1,61 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+/** @noinspection PhpDocSignatureInspection */
+
+namespace webignition\BasilParser\Tests\Unit\PageCollection;
+
+use Symfony\Component\Yaml\Parser as YamlParser;
+use webignition\BasilParser\Exception\NonRetrievablePageException;
+use webignition\BasilParser\Exception\UnknownPageException;
+use webignition\BasilParser\Factory\PageFactory;
+use webignition\BasilParser\Loader\PageLoader;
+use webignition\BasilParser\Loader\YamlLoader;
+use webignition\BasilParser\Model\Page\PageInterface;
+use webignition\BasilParser\PageCollection\PageCollection;
+use webignition\BasilParser\Tests\Services\FixturePathFinder;
+
+class PageCollectionTest extends \PHPUnit\Framework\TestCase
+{
+    public function testFindPageSuccess()
+    {
+        $pageCollection = new PageCollection($this->createPageLoader(), [
+            'page_import_name' => FixturePathFinder::find('Page/example.com.heading.yml'),
+        ]);
+
+        $page = $pageCollection->findPage('page_import_name');
+
+        $this->assertInstanceOf(PageInterface::class, $page);
+    }
+
+    public function testFindPageThrowsUnknownPageException()
+    {
+        $this->expectException(UnknownPageException::class);
+        $this->expectExceptionMessage('Unknown page "page_import_name"');
+
+        $pageCollection = new PageCollection($this->createPageLoader(), []);
+
+        $pageCollection->findPage('page_import_name');
+    }
+
+    public function testFindPageThrowsYamlLoaderException()
+    {
+        $this->expectException(NonRetrievablePageException::class);
+        $this->expectExceptionMessage('Cannot retrieve page "page_import_name" from "non-existent-file.yml"');
+
+        $pageCollection = new PageCollection($this->createPageLoader(), [
+            'page_import_name' => 'non-existent-file.yml',
+        ]);
+
+        $pageCollection->findPage('page_import_name');
+    }
+
+    private function createPageLoader()
+    {
+        $yamlParser = new YamlParser();
+
+        $yamlLoader = new YamlLoader($yamlParser);
+        $pageFactory = new PageFactory();
+
+        return new PageLoader($yamlLoader, $pageFactory);
+    }
+}

--- a/tests/Unit/Validator/AssertionValidatorTest.php
+++ b/tests/Unit/Validator/AssertionValidatorTest.php
@@ -1,4 +1,5 @@
 <?php
+/** @noinspection PhpUnhandledExceptionInspection */
 /** @noinspection PhpDocSignatureInspection */
 
 namespace webignition\BasilParser\Tests\Unit\Validator;
@@ -31,7 +32,7 @@ class AssertionValidatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testValidate(string $assertionString, bool $expectedIsValid)
     {
-        $assertion = $this->assertionFactory->createFromAssertionString($assertionString);
+        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, []);
 
         $this->assertSame($expectedIsValid, $this->assertionValidator->validate($assertion));
     }

--- a/tests/Unit/Validator/AssertionValidatorTest.php
+++ b/tests/Unit/Validator/AssertionValidatorTest.php
@@ -5,6 +5,7 @@
 namespace webignition\BasilParser\Tests\Unit\Validator;
 
 use webignition\BasilParser\Factory\AssertionFactory;
+use webignition\BasilParser\PageCollection\EmptyPageCollection;
 use webignition\BasilParser\Validator\AssertionValidator;
 
 class AssertionValidatorTest extends \PHPUnit\Framework\TestCase
@@ -32,7 +33,7 @@ class AssertionValidatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testValidate(string $assertionString, bool $expectedIsValid)
     {
-        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, []);
+        $assertion = $this->assertionFactory->createFromAssertionString($assertionString, new EmptyPageCollection());
 
         $this->assertSame($expectedIsValid, $this->assertionValidator->validate($assertion));
     }


### PR DESCRIPTION
Fixes #118